### PR TITLE
Add Python 3.13+ code quality standards guide

### DIFF
--- a/global-scope/development-standards/SKILL.md
+++ b/global-scope/development-standards/SKILL.md
@@ -235,3 +235,9 @@ def calculate_impact_score(complexity: int, audit_rating: Optional[int] = None) 
 ### Remember
 
 The docs are the product. Documentation is a feature, not a chore. Invest the time to do it well.
+
+## Language-Specific Quality Standards
+
+Beyond automated checks (Ruff, mypy, ESLint), higher-level design patterns apply to each language:
+
+**Python 3.13+:** See `references/python-313-conventions.md` for modern idiom enforcement covering typing design, API contracts, error handling, async patterns, control flow, data semantics, architectural cohesion, testing practices, maintainability, and ethical considerations. This guide addresses what automation cannot check - the semantic and design patterns that require understanding intent.

--- a/global-scope/development-standards/references/python-313-conventions.md
+++ b/global-scope/development-standards/references/python-313-conventions.md
@@ -1,0 +1,101 @@
+# Python Code Review Guide - Beyond Automated Checks (Python 3.13)
+
+This guide defines higher-level review responsibilities for modern Python code. Ruff already enforces syntax, style, and basic modernization. Your task is to evaluate **design, semantics, and intent** - what automation cannot check.
+
+## 1. Typing Design
+
+| Watch For | Better Practice |
+|-----------|----------------|
+| Misuse of `Any` or overly-broad types | Constrain with `object`, `Protocol`, or proper generics |
+| Missing or misleading type hints | Ensure function signatures reflect actual contracts |
+| Overuse of `TypedDict` or `dataclass` where `Protocol` fits | Use constructs aligned with semantics (record vs behavior) |
+| Complex nested generics that harm readability | Alias intermediate types for clarity, e.g. `type UserMap = dict[int, User]` |
+
+## 2. API and Function Design
+
+| Watch For | Better Practice |
+|-----------|----------------|
+| Functions mixing concerns (I/O, logic, formatting) | Separate pure logic from side effects |
+| Too many positional arguments or hidden defaults | Use keyword-only arguments, dataclasses, or config objects |
+| Implicit resource lifecycles (e.g. open/close across calls) | Manage resources explicitly with context managers |
+| Leaky abstractions (e.g. returning raw DB rows, OS paths) | Return domain objects or sanitized values |
+
+## 3. Error Handling and Contracts
+
+| Watch For | Better Practice |
+|-----------|----------------|
+| Bare or over-broad `except Exception` | Catch only the expected errors |
+| Swallowing exceptions silently | Log or re-raise with context |
+| Assertions in production code | Replace with explicit validation (`ValueError`, `TypeError`) |
+| Returning sentinel values to indicate failure | Raise exceptions or use `Result`-style returns |
+
+## 4. Asynchronous and Concurrency Logic
+
+| Watch For | Better Practice |
+|-----------|----------------|
+| Blocking I/O inside async functions | Use non-blocking libraries (`aiofiles`, `httpx`, etc.) |
+| Detached tasks or missing `await` | Ensure tasks are tracked via `TaskGroup` or explicit `await` |
+| Unbounded concurrency or parallelism | Use semaphores or bounded executors |
+
+## 5. Control Flow and Readability
+
+| Watch For | Better Practice |
+|-----------|----------------|
+| Deeply nested `if`/`else`/`try` structures | Flatten with early returns or guard clauses |
+| Flag variables acting as implicit state machines | Use `Enum` or `match` statements for clarity |
+| Side effects inside comprehensions | Keep comprehensions pure and move side effects out |
+
+## 6. Data and Collection Semantics
+
+| Watch For | Better Practice |
+|-----------|----------------|
+| Mutating a collection while iterating | Iterate over a copy or collect changes separately |
+| Relying on implicit ordering in sets/dicts | Sort explicitly or use `OrderedDict` |
+| Manual caching or memoization | Use `functools.cache` or `lru_cache` decorators |
+
+## 7. Architectural Cohesion
+
+| Watch For | Better Practice |
+|-----------|----------------|
+| Functions or classes with too many responsibilities | Apply the single-responsibility principle |
+| Hidden global state or implicit singletons | Pass dependencies explicitly |
+| Tight coupling between modules | Use interfaces or dependency injection |
+| Reimplementing stdlib behavior | Prefer standard modules like `itertools`, `functools`, `contextlib` |
+
+## 8. Testing and Contracts
+
+| Watch For | Better Practice |
+|-----------|----------------|
+| Non-deterministic tests (time, randomness, I/O) | Seed randomness or mock external dependencies |
+| Missing failure-path tests | Include negative and edge cases |
+| Assertions with unclear messages | Use explicit messages or `pytest.raises` for clarity |
+
+## 9. Maintainability and Clarity
+
+| Watch For | Better Practice |
+|-----------|----------------|
+| Comments explaining *what* the code does | Explain *why* decisions were made |
+| Clever or overly compressed one-liners | Prefer explicit and readable constructs |
+| Undocumented module or function purpose | Add concise docstrings summarizing intent |
+
+## 10. Ethical and Safety Considerations
+
+| Watch For | Better Practice |
+|-----------|----------------|
+| Misleading variable or function names | Use accurate, intention-revealing naming |
+| Hidden side effects (network, subprocess, filesystem) | Document all external interactions |
+| Serialization or deserialization without validation | Validate data before use (`pydantic`, `dataclasses`, schema libraries) |
+
+## Reviewer Checklist
+
+- Function and class boundaries make logical sense
+- Exceptions are explicit and meaningful
+- Async code never blocks or leaks tasks
+- No hidden global state or circular dependencies
+- Comments describe intent, not implementation
+- Typing reflects true contracts
+- No magical or surprising behavior left unexplained
+
+---
+
+Last updated for Python 3.13 / Ruff 0.6


### PR DESCRIPTION
## Summary

Extends the development-standards skill with language-specific quality guidelines for Python 3.13+. This reference document covers semantic and design patterns that automated tools (Ruff, mypy) cannot check - the aspects requiring human judgment about intent and architecture.

## What's Added

- **`references/python-313-conventions.md`**: Comprehensive code review guide
  - 10 dimensions of quality beyond automation
  - Table-based format: "Watch For" vs "Better Practice"
  - Covers typing design, API design, error handling, async patterns, control flow, data semantics, architectural cohesion, testing contracts, maintainability, and ethical considerations

- Updated `SKILL.md` to reference the new Python conventions in a new "Language-Specific Quality Standards" section

## Rationale

While automated tooling (Ruff, mypy, pytest) catches syntax and style issues, reviewers need guidance on higher-level concerns like:
- API design choices (when to use `__init__` vs class methods)
- Error handling patterns (specific exceptions vs broad catches)
- Async patterns (proper task management, cancellation)
- Typing design (protocols vs unions, TypedDict vs dataclasses)
- Architectural decisions (cohesion, testability, maintainability)

This guide fills that gap for Python projects, focusing on patterns that require understanding intent and context rather than mechanical checking.

## Test Plan

- [x] Review document structure and formatting
- [x] Verify all 10 dimensions are covered comprehensively
- [x] Ensure examples are clear and actionable
- [x] Check that SKILL.md correctly references the new document
- [x] Confirm document follows repo standards (no emoji, modern conventions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)