### PR TITLE
Add project-scope skills for Read the Docs and Write the Docs

### DIFF
--- a/project-scope/rtd/README.md
+++ b/project-scope/rtd/README.md
@@ -1,0 +1,48 @@
+# Read the Docs Skills
+
+This directory contains Claude Code skills specific to the Read the Docs project.
+
+## Project Overview
+
+Read the Docs (https://github.com/readthedocs/readthedocs.org) is an open-source platform for hosting and building documentation. The project is a Django monolith with a multi-instance architecture where the same codebase is deployed as three separate instances:
+
+- **Web** - Dashboard, user interface, and API
+- **Build** - Executes documentation builds in isolated Docker containers
+- **Proxito** - Serves documentation pages to end users
+
+All development is done via Docker Compose with PostgreSQL, Redis, Elasticsearch, MinIO (S3-compatible storage), and nginx for routing.
+
+## Technology Stack
+
+- Django (Python web framework)
+- Docker and Docker Compose
+- PostgreSQL (database)
+- Redis (caching and task queue)
+- Elasticsearch (search functionality)
+- Celery (async task processing)
+- Sphinx and MkDocs (documentation builders)
+
+## Development Approach
+
+- Docker-first development environment
+- Pytest with instance-specific test markers
+- Pre-commit hooks for code quality
+- Fork-based contribution workflow
+- Class-based settings inheritance
+- Custom database routing for telemetry
+- Git submodule for shared configuration (common/)
+
+## Skills in This Directory
+
+- **rtd-code-standards** - Code quality and style standards for Python contributions
+- **rtd-contribution-workflow** - Fork-based Git and PR workflow for contributing
+- **rtd-docs-standards** - ReStructuredText documentation standards
+
+## Key Characteristics
+
+- Multi-instance Django architecture (web, build, proxito)
+- Isolated Docker-based documentation builds with gVisor sandboxing
+- Test suite separated by instance type using pytest markers
+- Settings organized using class-based inheritance
+- Development requires invoke tasks for common operations
+- Strong emphasis on code quality (Ruff, pre-commit, tox)

--- a/project-scope/rtd/rtd-code-standards/SKILL.md
+++ b/project-scope/rtd/rtd-code-standards/SKILL.md
@@ -1,0 +1,399 @@
+---
+name: rtd-code-standards
+description: Code quality and style standards for Read the Docs contributions. Use when writing Python code, creating tests, or preparing code changes for PR submission. Covers Ruff configuration, testing requirements, pre-commit hooks, import sorting, and migration checks.
+---
+
+# Read the Docs Code Standards
+
+## Overview
+
+This skill defines the code quality and style standards for contributing Python code to Read the Docs. Follow these standards to ensure code changes pass CI checks and meet project quality expectations.
+
+## Python Style Standards
+
+### Code Formatting
+
+Read the Docs uses **Ruff** for both linting and formatting.
+
+**Key rules:**
+- Line length: **100 characters maximum**
+- Indentation: **4 spaces** (no tabs)
+- Python version target: **Python 3.12**
+- Quote style: Double quotes preferred
+
+**Configuration location:** `common/.ruff.toml` (symlinked from common submodule)
+
+### Import Sorting
+
+Imports must be sorted using Ruff's isort functionality:
+
+**Rules:**
+- **Single-line imports** (not multi-line from imports)
+- **Case-insensitive** alphabetical sorting
+- **Grouping order:**
+  1. Standard library
+  2. Third-party packages
+  3. First-party (readthedocs, readthedocsext, readthedocscinc)
+  4. Local/relative imports
+
+**Example:**
+```python
+import os
+import sys
+from pathlib import Path
+
+from django.conf import settings
+from django.db import models
+import requests
+
+from readthedocs.builds.models import Build
+from readthedocs.core.utils import trigger_build
+from readthedocsext.theme import apply_theme
+
+from .utils import helper_function
+```
+
+### Running Code Formatters
+
+```bash
+# Run all pre-commit hooks (includes Ruff)
+pre-commit run --all-files
+
+# Via tox
+tox -e pre-commit
+
+# Ruff directly (if needed)
+ruff check .
+ruff format .
+```
+
+## Testing Requirements
+
+### Test Organization
+
+Tests are **co-located** with code in each Django app:
+
+```
+readthedocs/
+├── projects/
+│   ├── models.py
+│   ├── views.py
+│   └── tests/
+│       ├── test_models.py
+│       ├── test_views.py
+│       └── test_api.py
+├── builds/
+│   └── tests/
+└── rtd_tests/  # Shared test utilities
+    ├── base.py
+    ├── fixtures/
+    ├── mocks/
+    └── utils.py
+```
+
+### Pytest Markers
+
+Use markers to categorize tests by instance type:
+
+```python
+import pytest
+
+# No marker = main instance test (default)
+def test_project_creation():
+    pass
+
+# Proxito instance test
+@pytest.mark.proxito
+def test_doc_serving():
+    pass
+
+# Requires Elasticsearch
+@pytest.mark.search
+def test_search_indexing():
+    pass
+
+# Embed API test
+@pytest.mark.embed_api
+def test_embed_endpoint():
+    pass
+```
+
+### Writing Tests
+
+**Requirements:**
+- Every new function/class needs tests
+- Test both happy path and error cases
+- Use fixtures from `readthedocs/rtd_tests/`
+- Mock external dependencies
+- Follow existing patterns in the app
+
+**Example test structure:**
+```python
+from django.test import TestCase
+from readthedocs.projects.models import Project
+from readthedocs.rtd_tests.base import RequestFactoryTestMixin
+
+class ProjectModelTest(RequestFactoryTestMixin, TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(
+            name="test-project",
+            slug="test-project"
+        )
+
+    def test_project_creation(self):
+        """Test that projects are created correctly."""
+        self.assertEqual(self.project.name, "test-project")
+        self.assertEqual(self.project.slug, "test-project")
+
+    def test_project_str_representation(self):
+        """Test string representation."""
+        self.assertEqual(str(self.project), "test-project")
+```
+
+### Running Tests
+
+```bash
+# Run all tests
+tox
+
+# Run specific test environment
+tox -e py312
+
+# Run specific test file
+tox -e py312 -- readthedocs/projects/tests/test_models.py
+
+# Run specific test function
+tox -e py312 -- -k test_project_creation
+
+# Run tests excluding search (don't need Elasticsearch)
+tox -e py312 -- -m "not search"
+
+# Inside Docker
+inv docker.test
+inv docker.test --arguments "-e py312 -- -k test_name"
+```
+
+### Test Coverage
+
+- All code changes should maintain or improve coverage
+- Coverage reports generated in CI via Codecov
+- Check coverage locally: `tox -e coverage`
+
+## Pre-Commit Hooks
+
+Read the Docs uses pre-commit hooks for automated quality checks.
+
+### Hooks Enabled
+
+From `common/pre-commit-config.yaml`:
+
+1. **Ruff** (v0.11.5)
+   - Linting and formatting
+   - Import sorting
+   - Auto-fixes applied
+
+2. **django-upgrade** (1.24.0)
+   - Modernizes Django patterns
+   - Target: Django 5.2
+
+3. **blacken-docs** (1.19.1)
+   - Formats code blocks in documentation
+
+4. **Standard hooks**
+   - Trailing whitespace removal
+   - End-of-file fixer
+   - YAML/JSON syntax validation
+   - Merge conflict detection
+
+### Running Pre-Commit
+
+```bash
+# Run all hooks on all files
+pre-commit run --all-files
+
+# Run all hooks on staged files only
+pre-commit run
+
+# Run specific hook
+pre-commit run ruff --all-files
+
+# Via tox
+tox -e pre-commit
+```
+
+**Before every PR:**
+```bash
+# REQUIRED: Run this before submitting PR
+tox -e pre-commit
+```
+
+## Database Migrations
+
+### Migration Requirements
+
+If code changes modify Django models, migrations are **required**.
+
+### Checking for Missing Migrations
+
+```bash
+# Via tox (what CI runs)
+tox -e migrations
+
+# Via invoke (inside Docker)
+inv docker.manage makemigrations --check --dry-run
+
+# Direct Django command
+python manage.py makemigrations --check --dry-run
+```
+
+### Creating Migrations
+
+```bash
+# Inside Docker
+inv docker.manage makemigrations
+
+# With specific app
+inv docker.manage makemigrations projects
+
+# Outside Docker
+python manage.py makemigrations
+```
+
+### Migration Best Practices
+
+- Review generated migrations before committing
+- Name migrations descriptively if needed
+- Test migrations can be applied and reversed
+- Include migrations in same commit as model changes
+- Document complex data migrations
+
+## Code Quality Checklist
+
+Before submitting a PR, verify:
+
+### 1. Formatting and Linting
+```bash
+✓ pre-commit run --all-files
+```
+
+### 2. Tests
+```bash
+✓ tox -e py312
+# All tests pass
+# New tests added for new code
+```
+
+### 3. Migrations
+```bash
+✓ tox -e migrations
+# No missing migrations
+```
+
+### 4. Test Coverage
+```bash
+✓ tox -e coverage
+# Coverage maintained or improved
+```
+
+### 5. Code Review Ready
+- [ ] Code follows Python 3.12 patterns
+- [ ] Imports properly sorted
+- [ ] Tests co-located with code
+- [ ] Docstrings on public functions/classes
+- [ ] No commented-out code
+- [ ] No debug print statements
+- [ ] No unnecessary complexity
+
+## Common Patterns
+
+### Django Model Patterns
+
+```python
+from django.db import models
+
+class MyModel(models.Model):
+    """Model docstring explaining purpose."""
+
+    # Fields with help_text
+    name = models.CharField(
+        max_length=255,
+        help_text="Human-readable name"
+    )
+
+    class Meta:
+        ordering = ["-created"]
+        verbose_name_plural = "my models"
+
+    def __str__(self):
+        return self.name
+
+    def save(self, *args, **kwargs):
+        # Custom save logic
+        super().save(*args, **kwargs)
+```
+
+### View Patterns
+
+```python
+from django.views.generic import DetailView
+from .models import Project
+
+class ProjectDetailView(DetailView):
+    model = Project
+    template_name = "projects/project_detail.html"
+
+    def get_queryset(self):
+        # Custom queryset logic
+        return super().get_queryset().filter(active=True)
+```
+
+### Test Fixture Usage
+
+```python
+from readthedocs.rtd_tests.fixtures import get_factory
+
+def test_with_fixture():
+    # Use fixture factories
+    project = get_factory("Project").create(name="test")
+    build = get_factory("Build").create(project=project)
+```
+
+## Django-Specific Standards
+
+### Settings Configuration
+
+- Use class-based settings (inherit from `CommunityBaseSettings`)
+- Override with `@property` decorator for dynamic values
+- Never hardcode secrets
+- Use environment variables for configuration
+
+### Database Queries
+
+- Use `select_related()` and `prefetch_related()` to avoid N+1 queries
+- Index frequently queried fields
+- Be mindful of query performance
+
+### Celery Tasks
+
+- Use `@app.task` decorator
+- Make tasks idempotent
+- Handle failures gracefully
+- Log task execution
+
+## Resources
+
+This skill focuses on code standards. For documentation standards, use the `rtd-docs-standards` skill. For Git workflow and PR process, use the `rtd-contribution-workflow` skill.
+
+## CI/CD Integration
+
+CircleCI runs these checks on every PR:
+
+**checks job:**
+- `pre-commit run --all-files`
+- `tox -e migrations`
+
+**tests job:**
+- `tox -e py312`
+- Coverage report to Codecov
+
+All must pass before merge.

--- a/project-scope/rtd/rtd-contribution-workflow/SKILL.md
+++ b/project-scope/rtd/rtd-contribution-workflow/SKILL.md
@@ -1,0 +1,366 @@
+---
+name: rtd-contribution-workflow
+description: Guide the Git and pull request workflow for contributing to Read the Docs (readthedocs/readthedocs.org) from a personal fork. Use when creating branches, making commits, or submitting PRs to the Read the Docs project. Covers fork-based workflow, branch naming, commit messages, PR creation, CI/CD checks, and review process.
+---
+
+# Read the Docs Contribution Workflow
+
+## Overview
+
+This skill provides the complete workflow for contributing to Read the Docs (readthedocs/readthedocs.org) from a personal fork. It covers Git operations, branch management, commit formatting, cross-repository pull request creation, and the review process.
+
+## Fork-Based Workflow
+
+Read the Docs follows a standard fork-based contribution model where contributors work in their own forks and submit cross-repository pull requests.
+
+### Initial Setup
+
+```bash
+# Fork the repository on GitHub first (via web UI)
+
+# Clone your fork
+git clone --recurse-submodules git@github.com:YOUR-USERNAME/readthedocs.org.git
+cd readthedocs.org
+
+# Add upstream remote
+git remote add upstream https://github.com/readthedocs/readthedocs.org.git
+
+# Verify remotes
+git remote -v
+# Should show:
+# origin    git@github.com:YOUR-USERNAME/readthedocs.org.git (fetch/push)
+# upstream  https://github.com/readthedocs/readthedocs.org.git (fetch/push)
+```
+
+### Keeping Fork in Sync
+
+Before starting work on any issue, sync your fork with upstream:
+
+```bash
+# Fetch latest changes from upstream
+git fetch upstream
+
+# Update your local main branch
+git checkout main
+git merge upstream/main --ff-only
+
+# Push updates to your fork
+git push origin main
+```
+
+## Branch Naming Conventions
+
+Branch names should follow the pattern: `category/brief-description`
+
+**Common categories:**
+- `docs/` - Documentation changes
+- `fix/` - Bug fixes
+- `build/` - Build system changes
+- `search/` - Search-related features
+- `api/` - API changes
+- `test/` - Test improvements
+- `feature/` - New features
+
+**Examples:**
+```bash
+# For issue #7761 (document --backupdb argument)
+git checkout -b docs/document-backupdb-argument
+
+# For a bug fix
+git checkout -b fix/multiple-integrations-error
+
+# For a build improvement
+git checkout -b build/update-python-versions
+```
+
+**Pattern:** Use lowercase, hyphens for spaces, descriptive but concise
+
+## Commit Message Format
+
+Commit messages must follow this exact format:
+
+```
+Category: brief description in imperative mood (#issue)
+```
+
+**Rules:**
+- Start with category (same as branch prefix: Docs, Fix, Build, Search, API, etc.)
+- Use imperative mood ("add" not "added", "fix" not "fixed")
+- Capitalize only the first word (sentence case)
+- No trailing period
+- Include issue number in parentheses if applicable
+- Keep under 72 characters for the subject line
+
+**Examples:**
+```bash
+git commit -m "Docs: document --backupdb argument (#7761)"
+git commit -m "Fix: handle MultipleObjectsReturned in integration lookup (#12581)"
+git commit -m "Build: add Python 3.14 to build images (#12523)"
+git commit -m "Search: optimize queryset for subproject search"
+git commit -m "Dependencies: update all packages via pip-tools"
+```
+
+**What NOT to do:**
+```bash
+# ❌ Wrong: not imperative mood
+git commit -m "Docs: documented the backupdb argument"
+
+# ❌ Wrong: trailing period
+git commit -m "Fix: handle duplicate integrations."
+
+# ❌ Wrong: missing category
+git commit -m "Update documentation for backupdb"
+
+# ❌ Wrong: title case instead of sentence case
+git commit -m "Docs: Document --backupdb Argument"
+```
+
+## Creating a Pull Request
+
+### Pre-Submit Checklist
+
+Before creating a PR, verify all checks pass:
+
+```bash
+# 1. Run full test suite
+tox
+# or inside Docker:
+inv docker.test
+
+# 2. Run linting
+tox -e pre-commit
+# or directly:
+pre-commit run --all-files
+
+# 3. Check for missing migrations (if code changes models)
+tox -e migrations
+# or:
+inv docker.manage makemigrations --check --dry-run
+
+# 4. If documentation changes, build locally
+cd docs && make html
+# or:
+tox -e docs
+```
+
+### Push to Your Fork
+
+```bash
+# Push your feature branch to your fork
+git push origin docs/document-backupdb-argument
+
+# If you need to force push after rebase (use with caution)
+git push origin docs/document-backupdb-argument --force-with-lease
+```
+
+### Create Cross-Repository PR
+
+Since you're working from a fork, the PR must specify both repositories:
+
+```bash
+# Using GitHub CLI (recommended)
+gh pr create \
+  --repo readthedocs/readthedocs.org \
+  --base main \
+  --head YOUR-USERNAME:docs/document-backupdb-argument \
+  --title "Docs: document --backupdb argument (#7761)" \
+  --body "$(cat <<'EOF'
+[Problem statement - what issue this solves]
+
+## Changes
+
+- [Bullet point of change 1]
+- [Bullet point of change 2]
+- [Bullet point of change 3]
+
+[Verification statement - how you tested]
+
+Closes #7761
+EOF
+)"
+```
+
+**PR Title Format:**
+- Must match commit message format: `Category: description (#issue)`
+- Will be used as the merge commit message
+
+**PR Description Template:**
+```markdown
+[1-2 sentence problem statement explaining what issue this addresses]
+
+## Changes
+
+- [Specific change 1]
+- [Specific change 2]
+- [Specific change 3]
+
+[1-2 sentences about how changes were tested and verified]
+
+Closes #ISSUE_NUMBER
+```
+
+**Real Example (from merged PR #12583):**
+```markdown
+Docusaurus requires the `trailingSlash` option to be explicitly set when hosting on Read the Docs to avoid redirect issues.
+
+## Changes
+
+- Added section to Docusaurus guide documenting the `trailingSlash: true` requirement
+- Explained why this is necessary (Read the Docs URL structure)
+- Included code example in the configuration
+
+Successfully built documentation locally and verified rendering.
+
+Closes #12570
+```
+
+### Alternative: Create PR via GitHub Web UI
+
+If not using `gh` CLI:
+
+1. Push branch to your fork (see above)
+2. Visit https://github.com/readthedocs/readthedocs.org
+3. GitHub will show "Compare & pull request" banner
+4. Verify base repository is `readthedocs/readthedocs.org` and base branch is `main`
+5. Verify head repository is `YOUR-USERNAME/readthedocs.org` and compare branch is your feature branch
+6. Fill in title and description following format above
+7. Click "Create pull request"
+
+## CI/CD Checks
+
+Read the Docs uses CircleCI. All PRs must pass three jobs:
+
+### 1. checks
+- Pre-commit hooks (linting, formatting)
+- Migration checks
+- **Must pass** before merge
+
+### 2. tests
+- Main test suite (Python 3.12)
+- Includes search tests with Elasticsearch
+- Full pytest run with coverage
+- **Must pass** before merge
+
+### 3. tests-embedapi
+- Embed API test suite
+- Separate test configuration
+- **Must pass** before merge
+
+### Monitoring CI Status
+
+```bash
+# Check PR status and CI checks
+gh pr view --repo readthedocs/readthedocs.org PR_NUMBER
+
+# Check only CI status
+gh pr checks --repo readthedocs/readthedocs.org PR_NUMBER
+
+# View PR in browser
+gh pr view --repo readthedocs/readthedocs.org PR_NUMBER --web
+```
+
+### Common CI Failures
+
+**Vale linting failures:**
+- Run locally: `vale docs/user/` or `vale docs/dev/`
+- Fix prose style issues
+- Commit and push fixes
+
+**Migration check failures:**
+- Run: `inv docker.manage makemigrations`
+- Commit generated migrations
+- Push to PR
+
+**Test failures:**
+- Run locally: `tox -e py312 -- -k test_name`
+- Debug and fix
+- Verify all tests pass before pushing
+
+## Review Process
+
+### What to Expect
+
+1. **Response time:** Core team typically responds within 1-2 business days
+2. **Review depth:** Expect thorough, constructive feedback
+3. **Iteration:** Multiple review rounds are common for complex changes
+4. **Documentation previews:** Check auto-generated preview link in PR comments
+
+### Responding to Review Feedback
+
+**When reviewer requests changes:**
+
+```bash
+# Make requested changes in your branch
+git add changed-files
+git commit -m "Address review feedback"
+git push origin docs/document-backupdb-argument
+```
+
+**When reviewer suggests specific edits:**
+- Implement suggestions
+- Reply to comments acknowledging changes
+- Use "Resolve conversation" when fully addressed
+
+**Response tone:**
+- Professional and collaborative
+- Don't argue or defend - iterate
+- Ask clarifying questions if feedback is unclear
+- Thank reviewers for their time
+
+### Example Review Interactions
+
+**Good response:**
+```
+Thanks for the feedback! I've updated the documentation to:
+- Use :guilabel: for the button reference (line 45)
+- Break the sentence at semantic boundaries (lines 52-54)
+- Add periods to all bullet points (lines 60-65)
+
+Let me know if this looks better!
+```
+
+**Request for clarification:**
+```
+Thanks for reviewing! Quick question about your suggestion on line 30:
+
+> "Consider using a code-block directive here"
+
+Do you mean a `.. code-block:: python` directive, or the inline `:code:` role?
+The current example is just a one-liner - want to make sure I understand the preferred style.
+```
+
+## Merge and Cleanup
+
+Once approved and CI passes, the core team will merge your PR.
+
+### Post-Merge Cleanup
+
+```bash
+# Switch to main branch
+git checkout main
+
+# Fetch and merge upstream changes (includes your PR)
+git fetch upstream
+git merge upstream/main --ff-only
+
+# Push to your fork
+git push origin main
+
+# Delete your feature branch locally
+git branch -d docs/document-backupdb-argument
+
+# Delete your feature branch on your fork
+git push origin --delete docs/document-backupdb-argument
+```
+
+## Resources
+
+### references/gh-commands.md
+
+Comprehensive GitHub CLI command reference for working with PRs and issues. Load this when you need advanced GitHub CLI functionality beyond the basics covered here.
+
+### Additional References
+
+- CircleCI dashboard: https://circleci.com/gh/readthedocs/readthedocs.org
+- Good first issues: https://github.com/readthedocs/readthedocs.org/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22
+- Contributing guide: https://docs.readthedocs.io/en/latest/contribute.html

--- a/project-scope/rtd/rtd-contribution-workflow/references/gh-commands.md
+++ b/project-scope/rtd/rtd-contribution-workflow/references/gh-commands.md
@@ -1,0 +1,106 @@
+# GitHub CLI Commands Reference
+
+Comprehensive reference for `gh` CLI commands when working with Read the Docs contributions.
+
+## Pull Request Commands
+
+### Viewing PRs
+
+```bash
+# List all open PRs
+gh pr list --repo readthedocs/readthedocs.org
+
+# List your PRs
+gh pr list --repo readthedocs/readthedocs.org --author @me
+
+# List PRs by label
+gh pr list --repo readthedocs/readthedocs.org --label "good first issue"
+
+# View specific PR details
+gh pr view --repo readthedocs/readthedocs.org 12583
+
+# View PR in browser
+gh pr view --repo readthedocs/readthedocs.org 12583 --web
+
+# View PR diff
+gh pr diff --repo readthedocs/readthedocs.org 12583
+```
+
+### Creating PRs
+
+```bash
+# Create PR with prompts (interactive)
+gh pr create --repo readthedocs/readthedocs.org
+
+# Create PR with all details (non-interactive)
+gh pr create \
+  --repo readthedocs/readthedocs.org \
+  --base main \
+  --head username:branch-name \
+  --title "Category: description (#issue)" \
+  --body "Description here"
+
+# Create draft PR
+gh pr create \
+  --repo readthedocs/readthedocs.org \
+  --draft \
+  --title "WIP: Feature name"
+```
+
+### Checking CI Status
+
+```bash
+# Check all CI checks for a PR
+gh pr checks --repo readthedocs/readthedocs.org 12583
+
+# Watch CI checks (auto-refresh)
+gh pr checks --repo readthedocs/readthedocs.org 12583 --watch
+
+# Check specific workflow
+gh run list --repo readthedocs/readthedocs.org --branch branch-name
+```
+
+### Updating PRs
+
+```bash
+# Add comment to PR
+gh pr comment --repo readthedocs/readthedocs.org 12583 --body "Updated based on feedback"
+
+# Edit PR title/description
+gh pr edit --repo readthedocs/readthedocs.org 12583 --title "New title"
+
+# Mark PR as ready for review (un-draft)
+gh pr ready --repo readthedocs/readthedocs.org 12583
+```
+
+## Issue Commands
+
+### Viewing Issues
+
+```bash
+# List all open issues
+gh issue list --repo readthedocs/readthedocs.org
+
+# List by label
+gh issue list --repo readthedocs/readthedocs.org --label "good first issue"
+gh issue list --repo readthedocs/readthedocs.org --label "Sprintable"
+
+# View specific issue
+gh issue view --repo readthedocs/readthedocs.org 7761
+
+# View issue in browser
+gh issue view --repo readthedocs/readthedocs.org 7761 --web
+```
+
+### Common Patterns
+
+```bash
+# Find good first issues
+gh issue list --repo readthedocs/readthedocs.org --label "good first issue" --label "Accepted"
+
+# Search issues
+gh search issues --repo readthedocs/readthedocs.org "documentation"
+
+# Check issue status
+gh issue view --repo readthedocs/readthedocs.org 7761 --json state,assignees,labels
+```

--- a/project-scope/rtd/rtd-docs-standards/SKILL.md
+++ b/project-scope/rtd/rtd-docs-standards/SKILL.md
@@ -1,0 +1,437 @@
+---
+name: rtd-docs-standards
+description: Documentation writing standards for Read the Docs. Use when writing or editing ReStructuredText documentation files. Covers RST style guide, Diátaxis framework, Vale linting, brand guidelines, headline hierarchy, cross-references, and word list. Essential for documentation PRs.
+---
+
+# Read the Docs Documentation Standards
+
+## Overview
+
+This skill defines the documentation writing standards for Read the Docs. Follow these guidelines when creating or editing documentation to ensure consistency, quality, and successful Vale linting checks.
+
+## Brand Guidelines
+
+### Project Name
+
+**Correct:** "Read the Docs" (three words, title case)
+**Incorrect:** "Read The Docs", "ReadTheDocs", "RTD" (in prose)
+
+**Acronym:** "RTD" is acceptable in technical contexts (URLs, code) but spell out "Read the Docs" in prose.
+
+### Capitalization
+
+Use **sentence case** for all headings and titles:
+- **Correct:** "Install Read the Docs"
+- **Incorrect:** "Install Read The Docs"
+
+Only capitalize proper nouns and the first word.
+
+## ReStructuredText Style
+
+### Headline Hierarchy
+
+Use this exact hierarchy for section headers:
+
+```rst
+Header Level 1
+==============
+
+Header Level 2
+--------------
+
+Header Level 3
+~~~~~~~~~~~~~~
+
+Header Level 4
+^^^^^^^^^^^^^^
+```
+
+**Important:** The underline must be at least as long as the title text.
+
+### Line Breaks
+
+Break lines at **semantic boundaries** (periods, commas), not at arbitrary character counts (e.g., 80 chars).
+
+**Good:**
+```rst
+This is a complete sentence that describes a concept.
+It breaks at the period, maintaining readability.
+```
+
+**Bad:**
+```rst
+This is a complete sentence that describes a
+concept. It breaks mid-sentence arbitrarily.
+```
+
+### Inline Markup
+
+Use specific roles for different elements:
+
+**Interactive elements:**
+```rst
+:menuselection:`File --> Save` - For menu navigation
+:guilabel:`Save` - For buttons, labels, inputs
+:kbd:`Ctrl+S` - For keyboard shortcuts
+```
+
+**Technical elements:**
+```rst
+:program:`git` - For program/command names
+:command:`git commit` - For shell commands
+:file:`.readthedocs.yaml` - For file paths
+:code:`variable_name` - For inline code
+```
+
+**Bold text** (use `**text**`) for non-interactive visual elements that don't fit other roles.
+
+### Code Blocks
+
+Use code-block directive with language specification:
+
+```rst
+.. code-block:: python
+
+   def hello_world():
+       print("Hello, world!")
+
+.. code-block:: yaml
+
+   version: 2
+   build:
+     os: ubuntu-22.04
+
+.. code-block:: bash
+
+   git commit -m "Update documentation"
+```
+
+### Lists
+
+**All bullet list items must end with periods:**
+
+```rst
+- This is a list item.
+- This is another list item.
+- Even single-line items need periods.
+```
+
+**Numbered lists:**
+
+```rst
+1. First step with period.
+2. Second step with period.
+3. Third step with period.
+```
+
+### Cross-References
+
+**Link to other pages:**
+```rst
+:doc:`/path/to/document`
+:doc:`Link text </path/to/document>`
+```
+
+**Link to sections:**
+```rst
+.. _section-label:
+
+Section Title
+-------------
+
+Later reference it:
+:ref:`section-label`
+:ref:`Custom text <section-label>`
+```
+
+**External links:**
+```rst
+`Link text <https://example.com>`_
+```
+
+## Diátaxis Framework
+
+All documentation must fit one of these four categories:
+
+### 1. Tutorial
+- **Purpose:** Learning-oriented, teaching
+- **Content:** Step-by-step lessons for beginners
+- **Tone:** Encouraging, patient
+- **Example:** "Getting started with Read the Docs"
+
+### 2. How-to Guide
+- **Purpose:** Problem-oriented, practical
+- **Content:** Steps to solve specific problems
+- **Tone:** Direct, focused on goals
+- **Example:** "How to configure custom domains"
+
+### 3. Reference
+- **Purpose:** Information-oriented, factual
+- **Content:** Technical descriptions, API specs
+- **Tone:** Dry, precise, comprehensive
+- **Example:** "Configuration file reference"
+
+### 4. Explanation
+- **Purpose:** Understanding-oriented, conceptual
+- **Content:** Background, context, alternatives
+- **Tone:** Thoughtful, clarifying
+- **Example:** "Understanding build environments"
+
+**When writing, identify which category your content fits and follow that pattern.**
+
+## Word List
+
+Use these specific terms consistently:
+
+### Version Control
+- **Git** (uppercase) except when referencing the command: :program:\`git\`
+- **Git repository** (not "VCS" or "repo" in prose)
+- **Git provider** for GitHub/GitLab/Bitbucket/Gitea
+
+### Configuration
+- **`.readthedocs.yaml`** is the canonical config file name
+- **Configuration file** (not "config file" in formal docs)
+
+### Documentation Terms
+- **how-to guide** (with hyphens, lowercase unless starting sentence)
+- **documentation** (not "docs" in formal prose)
+
+### Read the Docs Specific
+- **Project** - A documentation project on Read the Docs
+- **Version** - A specific version of documentation (e.g., "latest", "stable")
+- **Build** - The process of building documentation
+
+## Vale Linting
+
+Read the Docs uses Vale for prose quality checking.
+
+### Running Vale
+
+```bash
+# Check user documentation
+vale docs/user/
+
+# Check developer documentation
+vale docs/dev/
+
+# Check specific file
+vale docs/user/config-file/v2.rst
+
+# Via pre-commit
+pre-commit run vale --all-files
+```
+
+### Common Vale Errors
+
+**Passive voice:**
+- **Bad:** "The configuration is read by Read the Docs"
+- **Good:** "Read the Docs reads the configuration"
+
+**Wordy phrases:**
+- **Bad:** "In order to configure..."
+- **Good:** "To configure..."
+
+**Unclear antecedents:**
+- **Bad:** "It will build the documentation"
+- **Good:** "Read the Docs will build the documentation"
+
+**Spelling and capitalization:**
+- Vale checks against custom dictionary
+- Follow brand guidelines strictly
+
+## Building Documentation Locally
+
+Before submitting documentation PRs:
+
+```bash
+# Build user docs
+cd docs && make html
+# Or: tox -e docs
+
+# Build developer docs
+cd docs && PROJECT=dev make html
+# Or: tox -e docs-dev
+
+# View output
+open _build/html/index.html
+```
+
+### Common Build Errors
+
+**Missing references:**
+```rst
+WARNING: undefined label: section-name
+```
+Fix: Check `:ref:` labels exist and are spelled correctly
+
+**Missing files:**
+```rst
+WARNING: document isn't included in any toctree
+```
+Fix: Add document to a `.. toctree::` directive
+
+## Documentation Structure
+
+### Developer Documentation
+
+Located in `docs/dev/`:
+- `install.rst` - Installation and setup
+- `contribute.rst` - Contribution guidelines
+- `tests.rst` - Testing guide
+- `style-guide.rst` - Documentation style (this skill's source)
+- `design/` - Design decisions and architecture
+
+### User Documentation
+
+Located in `docs/user/`:
+- `intro/` - Getting started guides (tutorials)
+- `guides/` - How-to guides
+- `reference/` - Configuration and API reference
+- `explanation/` - Conceptual documentation
+
+## Placeholders
+
+Use angle brackets for abstract concepts and variables:
+
+```rst
+Replace <username> with your GitHub username.
+Configure the <build.os> setting in your configuration file.
+```
+
+## Examples and Code Samples
+
+**Provide context:**
+```rst
+Here's an example configuration file for a Python project using Sphinx:
+
+.. code-block:: yaml
+
+   version: 2
+   build:
+     os: ubuntu-22.04
+     tools:
+       python: "3.12"
+
+   python:
+     install:
+       - requirements: docs/requirements.txt
+```
+
+**Explain what it does:**
+```rst
+This configuration:
+
+- Uses Ubuntu 22.04 for builds.
+- Installs Python 3.12.
+- Installs dependencies from docs/requirements.txt.
+```
+
+## Common Patterns
+
+### Documenting Commands
+
+```rst
+To check your configuration, run:
+
+.. code-block:: bash
+
+   readthedocs-build --config .readthedocs.yaml
+
+This validates your configuration file without starting a build.
+```
+
+### Documenting Configuration Options
+
+```rst
+.. option:: build.os
+
+   The operating system for the build environment.
+
+   **Type:** String
+
+   **Options:** ``ubuntu-20.04``, ``ubuntu-22.04``, ``ubuntu-24.04``
+
+   **Default:** ``ubuntu-22.04``
+
+   **Example:**
+
+   .. code-block:: yaml
+
+      build:
+        os: ubuntu-22.04
+```
+
+### Warning and Note Boxes
+
+```rst
+.. note::
+
+   This feature is only available for projects using configuration file v2.
+
+.. warning::
+
+   Changing this setting will trigger a rebuild of all versions.
+
+.. tip::
+
+   Use :menuselection:`Admin --> Advanced Settings` to configure this.
+```
+
+## Quality Checklist
+
+Before submitting documentation PRs:
+
+- [ ] Headlines use correct hierarchy (====, ----, ~~~~, ^^^^)
+- [ ] Lines break at semantic boundaries
+- [ ] All bullet points end with periods
+- [ ] Interactive elements use :guilabel: and :menuselection:
+- [ ] Code blocks specify language
+- [ ] "Read the Docs" spelled correctly (not "Read The Docs")
+- [ ] Sentence case for headings
+- [ ] Cross-references use :doc: and :ref: correctly
+- [ ] Vale linting passes: `vale docs/user/ docs/dev/`
+- [ ] Documentation builds successfully: `cd docs && make html`
+- [ ] Fits Diátaxis category (Tutorial, How-to, Reference, Explanation)
+
+## Building and Testing
+
+### Full Documentation Build
+
+```bash
+# From project root
+cd docs
+
+# Build user docs (default)
+make html
+
+# Build developer docs
+PROJECT=dev make html
+
+# Clean build (removes cached files)
+make clean html
+```
+
+### Via Tox
+
+```bash
+# User docs
+tox -e docs
+
+# Developer docs
+tox -e docs-dev
+```
+
+### Preview Build
+
+After pushing to PR, Read the Docs automatically generates a preview build. Check the link in PR comments to verify rendering.
+
+## Resources
+
+This skill focuses on documentation standards. For code standards, use the `rtd-code-standards` skill. For Git workflow and PR process, use the `rtd-contribution-workflow` skill.
+
+## References
+
+- Official style guide: `docs/dev/style-guide.rst`
+- Vale configuration: `common/vale.ini`
+- Diátaxis framework: https://diataxis.fr/
+- Sphinx ReStructuredText primer: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html

--- a/project-scope/wtd/README.md
+++ b/project-scope/wtd/README.md
@@ -1,0 +1,43 @@
+# Write the Docs Skills
+
+This directory contains Claude Code skills specific to the Write the Docs project.
+
+## Project Overview
+
+Write the Docs (https://github.com/writethedocs/www) is the official website for the Write the Docs global community, serving documentarians, technical writers, and documentation enthusiasts worldwide. The site features conference information, documentation guides, blog posts, and video archives.
+
+## Technology Stack
+
+- Sphinx 5.3.0 (static site generator)
+- Python 3.9.21
+- reStructuredText and Markdown (via MyST parser)
+- Jinja2 templating throughout
+- YAML-driven conference data
+- Deployed on Read the Docs
+
+## Development Approach
+
+- Jinja preprocessing on all RST files before Sphinx rendering
+- Data-driven conference pages with YAML schemas
+- Video archive system generating pages from YAML
+- Vale prose linting for content quality
+- HTML proofer for link validation
+- Fork-based contribution workflow
+- Comprehensive CI/CD with 6 automated checks
+
+## Skills in This Directory
+
+- **writethedocs-conference-workflow** - Complete workflow for creating and managing conference websites
+- **writethedocs-documentation-standards** - RST/Markdown standards, Vale rules, YAML schema management
+- **writethedocs-git-workflow** - Git workflow, PR process, and CI/CD checks
+
+## Key Characteristics
+
+- Conference data lives in structured YAML files with strict schemas
+- ALL RST files are Jinja-preprocessed with automatic context injection
+- Video builds are opt-in (slow) and filtered by year
+- Multi-timezone schedule support with DST awareness
+- Custom Sphinx extensions for video archives, meetups, and datatemplates
+- Legacy vs modern data formats (pre-2020 vs 2020+)
+- Strong emphasis on content quality (Vale, spellcheck, YAML validation)
+- Photo management with automatic fallbacks for missing images

--- a/project-scope/wtd/writethedocs-conference-workflow/SKILL.md
+++ b/project-scope/wtd/writethedocs-conference-workflow/SKILL.md
@@ -1,0 +1,623 @@
+---
+name: writethedocs-conference-workflow
+description: Complete workflow for creating and managing Write the Docs conference websites with YAML-driven pages. Use when setting up conference pages, managing conference lifecycle stages, or updating conference data.
+---
+
+# Write the Docs Conference Workflow
+
+This skill provides the complete workflow for creating, updating, and managing Write the Docs conference websites using YAML-driven data and flag-based feature toggles.
+
+## When to Use This Skill
+
+Use this skill when:
+- Setting up a new conference website
+- Updating conference through lifecycle stages (CFP → speakers → schedule → videos)
+- Managing conference YAML data files
+- Understanding flag-based feature toggles
+- Debugging conference page rendering
+
+## Conference Lifecycle Overview
+
+Conferences progress through stages controlled by feature flags:
+
+1. **Landing** (`flaglanding`) - Early announcement
+2. **CFP Open** (`flagcfp`) - Call for proposals
+3. **Speakers Announced** (`flagspeakersannounced`) - Speaker lineup published
+4. **Schedule Published** (`flaghasschedule`) - Full agenda available
+5. **Tickets On Sale** (`flagticketsonsale`) - Ticket sales active
+6. **Sold Out** (`flagsoldout`) - No tickets remaining
+7. **Livestreaming** (`flaglivestreaming`) - During conference
+8. **Post-Conference** (`flagpostconf`) - After event
+9. **Videos Published** (`flagvideos`) - Video archive available
+
+## Conference Data Structure
+
+Each conference requires 3 YAML files in `docs/_data/`:
+
+1. **Config** (`{shortcode}-{year}-config.yaml`) - Metadata, flags, sponsors
+2. **Sessions** (`{shortcode}-{year}-sessions.yaml`) - Speakers and talks
+3. **Schedule** (`{shortcode}-{year}-schedule.yaml`) - Time-ordered agenda
+
+Plus RST pages in `docs/conf/{shortcode}/{year}/`.
+
+## Stage 1: Conference Setup
+
+### Create Conference Directory
+
+```bash
+# Example for Portland 2026
+mkdir -p docs/conf/portland/2026
+cd docs/conf/portland/2026
+```
+
+### Copy from Previous Year
+
+```bash
+# Copy and update from previous year
+cp -r ../2025/* .
+
+# Update year references in all files
+# Change 2025 → 2026 throughout
+```
+
+### Create Initial Config YAML
+
+**File**: `docs/_data/portland-2026-config.yaml`
+
+**Minimum required**:
+```yaml
+name: Portland
+shortcode: portland
+year: 2026
+city: Portland
+local_area: North Portland
+area: Oregon, USA
+tz: America/Los_Angeles
+email: portland@writethedocs.org
+color: green
+time_format: 12h
+
+# Initial flags (all false except landing)
+flaglanding: true
+flagcfp: false
+flagspeakersannounced: false
+flaghasschedule: false
+flagticketsonsale: false
+flagsoldout: false
+flaghasshirts: false
+flaghasfood: false
+flaglivestreaming: false
+flagpostconf: false
+flagvideos: false
+
+date:
+  main: "**May 3-5, 2026**"
+  cfp_ends: "TBA"
+  tickets_live: "TBA"
+```
+
+See `references/conference-flags.md` for all flag definitions.
+
+### Create Conference Pages
+
+**Required pages in `docs/conf/{shortcode}/{year}/`**:
+
+- `index.rst` - Homepage
+- `cfp.rst` - Call for proposals (initially TBA)
+- `tickets.rst` - Ticket information (initially TBA)
+- `sponsors/prospectus.rst` - Sponsorship prospectus
+- `code-of-conduct.rst` - Code of conduct
+
+**Page template (`index.rst`)**:
+```rst
+:template: {{year}}/index.html
+:banner: _static/conf/images/headers/portland-2026-small-group.jpg
+:og:image: _static/conf/images/headers/portland-2026-opengraph.png
+:orphan:
+
+.. title:: Home | Write the docs Portland 2026
+
+Welcome to Write the Docs Portland 2026
+========================================
+
+Write the Docs Portland 2026 will be held **May 3-5, 2026** in Portland, Oregon.
+
+More details coming soon!
+```
+
+### Validate YAML
+
+```bash
+cd docs/_scripts
+./validate-yaml.sh
+```
+
+## Stage 2: CFP Open
+
+### Update Config Flags
+
+```yaml
+flaglanding: false  # No longer just landing
+flagcfp: true       # CFP is open
+```
+
+### Update CFP Details
+
+**In config YAML**:
+```yaml
+cfp_url: https://cfp.writethedocs.org/portland-2026
+date:
+  cfp_ends: "January 15, 2026"
+```
+
+**In `cfp.rst`**:
+- Add submission guidelines
+- Link to CFP system
+- Deadline information
+- Talk format details
+- Selection criteria
+
+### Announce CFP
+
+Create announcement in `docs/conf/portland/2026/news/`:
+
+**File**: `cfp-open.rst`
+```rst
+:template: {{year}}/generic.html
+
+.. post:: Oct 15, 2025
+   :tags: portland-2026, cfp
+
+CFP open for Portland 2026
+===========================
+
+The Call for Proposals for Write the Docs Portland 2026 is now open!
+
+Submit your talk proposals by **January 15, 2026**.
+
+More details: `/conf/portland/2026/cfp/`_
+```
+
+### Close CFP
+
+When deadline passes:
+```yaml
+flagcfp: false  # CFP closed
+```
+
+## Stage 3: Speakers Announced
+
+### Create Sessions YAML
+
+**File**: `docs/_data/portland-2026-sessions.yaml`
+
+Import from Pretalx:
+```bash
+cd docs/_scripts
+export PRETALX_TOKEN=your-token
+python pretalx2wtd.py
+# Edit year/city at bottom of script
+```
+
+Or create manually:
+```yaml
+- title: Documentation as code
+  slug: documentation-as-code
+  speakers:
+    - name: Jane Smith
+      slug: jane-smith
+      details: >
+        Jane Smith is a technical writer at Example Corp,
+        where she leads the docs-as-code initiative.
+  abstract: >
+    This talk explores treating documentation like code:
+    version control, automated testing, and continuous deployment.
+
+- title: Writing for developers
+  slug: writing-for-developers
+  speakers:
+    - name: John Doe
+      slug: john-doe
+      details: >
+        John Doe is a developer advocate with a passion
+        for clear, concise technical writing.
+  abstract: >
+    Developers need different documentation than end users.
+    Learn how to write effective API docs and getting started guides.
+```
+
+### Add Speaker Photos
+
+Place photos in `docs/_static/img/speakers/`:
+- Filename: `{speaker_slug}.jpg` (or .png)
+- Falls back to `missing.jpg` if not found
+
+Pretalx import script auto-downloads photos.
+
+### Update Flag
+
+```yaml
+flagspeakersannounced: true
+```
+
+### Create Speakers Page
+
+**File**: `docs/conf/portland/2026/speakers.rst`
+
+Uses datatemplates directive to render from YAML:
+```rst
+:template: {{year}}/generic.html
+
+Speakers
+========
+
+.. datatemplate::
+   :source: /_data/portland-2026-sessions.yaml
+   :template: {{year}}/speakers.html
+```
+
+### Announce Speakers
+
+Create news post:
+```rst
+:template: {{year}}/generic.html
+
+.. post:: Feb 1, 2026
+   :tags: portland-2026, speakers
+
+Announcing our Portland 2026 speakers
+======================================
+
+We're excited to announce the speaker lineup for Write the Docs Portland 2026!
+
+View the full lineup: `/conf/portland/2026/speakers/`_
+```
+
+### Validate
+
+```bash
+cd docs/_scripts
+./validate-yaml.sh
+
+# Build to test
+cd ../docs
+make html
+```
+
+## Stage 4: Schedule Published
+
+### Create Schedule YAML
+
+**File**: `docs/_data/portland-2026-schedule.yaml`
+
+```yaml
+unconf:
+  - time: "09:00"
+    title: Doors Open
+  - time: "10:00"
+    title: Writing Day Introduction
+  - time: "10:30"
+    title: Writing Sessions
+  - time: "12:00"
+    title: Lunch
+    icon: food
+  - time: "13:00"
+    title: Afternoon Writing Sessions
+  - time: "17:00"
+    title: Day 1 Wrap-Up
+
+talks_day1:
+  - time: "08:00"
+    title: Doors Open
+  - time: "09:00"
+    title: Welcome and Orientation
+  - time: "09:30"
+    title: Opening Keynote
+    slug: keynote-2026
+  - time: "10:15"
+    title: Morning Break
+    icon: food
+  - time: "10:45"
+    title: Documentation as Code
+    slug: documentation-as-code
+  - time: "11:30"
+    title: Writing for Developers
+    slug: writing-for-developers
+  - time: "12:15"
+    title: Lunch
+    icon: food
+  # ... more events
+
+talks_day2:
+  - time: "08:00"
+    title: Doors Open
+  - time: "09:00"
+    title: Day 2 Welcome
+  # ... more events
+```
+
+**Important**:
+- Times in 24-hour format (`"09:00"`, `"14:30"`)
+- Slugs must match sessions YAML
+- Use `icon: food` for meals/breaks
+
+### Preview Schedule
+
+```bash
+cd docs/_scripts
+python show-conf-schedule.py portland 2026
+```
+
+### Update Flag
+
+```yaml
+flaghasschedule: true
+```
+
+### Create Schedule Page
+
+**File**: `docs/conf/portland/2026/schedule.rst`
+
+```rst
+:template: {{year}}/schedule.html
+
+Schedule
+========
+
+Write the Docs Portland 2026 runs May 3-5, 2026.
+
+.. datatemplate::
+   :source: /_data/portland-2026-config.yaml
+   :source: /_data/portland-2026-schedule.yaml
+   :template: {{year}}/schedule.html
+```
+
+### Validate
+
+```bash
+cd docs/_scripts
+./validate-yaml.sh
+```
+
+## Stage 5: Tickets On Sale
+
+### Update Config
+
+```yaml
+flagticketsonsale: true
+tickets_url: https://ti.to/writethedocs/portland-2026
+
+date:
+  tickets_live: "February 1, 2026"
+```
+
+### Update Tickets Page
+
+**File**: `docs/conf/portland/2026/tickets.rst`
+
+- Ticket types and prices
+- Link to ticket platform
+- Refund policy
+- Financial assistance info
+
+## Stage 6: Sold Out (if applicable)
+
+```yaml
+flagticketsonsale: false
+flagsoldout: true
+```
+
+Update tickets page with sold-out notice.
+
+## Stage 7: During Conference
+
+### Enable Livestreaming
+
+About a week before:
+```yaml
+flaglivestreaming: true
+livestream_url: https://hopin.to/events/wtd-portland-2026
+```
+
+### During Event
+
+- Monitor livestream
+- Post updates to news
+- Engage with attendees
+
+### After Event Ends
+
+```yaml
+flaglivestreaming: false
+```
+
+## Stage 8: Post-Conference
+
+### Update Flag
+
+```yaml
+flagpostconf: true
+```
+
+### Add Thank You Post
+
+**File**: `docs/conf/portland/2026/news/thanks.rst`
+
+```rst
+:template: {{year}}/generic.html
+
+.. post:: May 10, 2026
+   :tags: portland-2026, recap
+
+Thank you Portland 2026!
+=========================
+
+Thank you to everyone who joined us for Write the Docs Portland 2026!
+
+Photos, videos, and talk summaries coming soon.
+```
+
+## Stage 9: Videos Published
+
+### Add YouTube IDs to Sessions
+
+Update `docs/_data/portland-2026-sessions.yaml`:
+```yaml
+- title: Documentation as code
+  slug: documentation-as-code
+  youtubeId: abc123xyz  # Add this
+  speakers:
+    # ... rest of session data
+```
+
+Or use script:
+```bash
+cd docs/_scripts
+python insert-video-ids.py
+```
+
+### Enable Video Flag
+
+```yaml
+flagvideos: true
+```
+
+### Build with Videos
+
+```bash
+cd docs
+BUILD_VIDEOS=True make html
+```
+
+This generates individual video pages in `docs/conf/portland/2026/videos/`.
+
+### Create Video Index
+
+**File**: `docs/conf/portland/2026/videos/index.rst`
+
+```rst
+:template: {{year}}/generic.html
+
+Videos
+======
+
+.. datatemplate::
+   :source: /_data/portland-2026-sessions.yaml
+   :template: {{year}}/video-listing.html
+```
+
+## Conference Flag Reference
+
+See `references/conference-flags.md` for complete flag definitions and usage.
+
+**Quick reference**:
+- `flaglanding` - Show landing page
+- `flagcfp` - CFP is open
+- `flagspeakersannounced` - Speakers published
+- `flaghasschedule` - Schedule available
+- `flagticketsonsale` - Tickets for sale
+- `flagsoldout` - Sold out
+- `flaghasshirts` - Shirts available
+- `flaghasfood` - Food info available
+- `flaglivestreaming` - Livestream active
+- `flagpostconf` - Post-conference mode
+- `flagvideos` - Videos published
+
+## Multi-Timezone Support
+
+For conferences with international audiences:
+
+```yaml
+tz: America/Los_Angeles
+tz2: Europe/Berlin
+tz2_color: blue
+time_format: 12h
+```
+
+Schedule automatically shows times in both timezones.
+
+## Testing Workflow
+
+**Before every change**:
+
+1. **Validate YAML**:
+   ```bash
+   cd docs/_scripts
+   ./validate-yaml.sh
+   ```
+
+2. **Build locally**:
+   ```bash
+   cd docs
+   make clean html
+   ```
+
+3. **Preview**:
+   ```bash
+   make livehtml
+   # http://127.0.0.1:8888
+   ```
+
+4. **Check conference pages**:
+   - Homepage
+   - Speakers (if flagspeakersannounced)
+   - Schedule (if flaghasschedule)
+   - Tickets
+
+## Common Issues
+
+### Schedule Slugs Don't Match
+
+**Error**: Slug in schedule.yaml not found in sessions.yaml
+
+**Fix**: Ensure exact match
+```yaml
+# sessions.yaml
+- slug: documentation-as-code
+
+# schedule.yaml
+- slug: documentation-as-code  # Must match exactly
+```
+
+### Photos Not Displaying
+
+**Issue**: Speaker photos show placeholder
+
+**Fix**: Check filename matches slug
+```
+docs/_static/img/speakers/jane-smith.jpg  # Filename
+slug: jane-smith  # In sessions YAML
+```
+
+### Time Format Issues
+
+**Issue**: Times showing wrong
+
+**Fix**: Always use 24-hour in YAML
+```yaml
+# In schedule YAML
+time: "14:30"  # Always 24-hour
+
+# In config YAML
+time_format: 12h  # Controls display only
+```
+
+### Video Build Slow
+
+**Issue**: `BUILD_VIDEOS=True` takes forever
+
+**Expected**: Videos generate ~100+ pages, this is normal
+
+**Solution**: Skip videos during development
+```bash
+make html  # Fast, no videos
+BUILD_VIDEOS=True make html  # Slow, with videos
+```
+
+## Additional Resources
+
+- See `references/conference-flags.md` for all flag definitions
+- See `references/yaml-templates.md` for complete YAML examples
+- Conference website guide: https://www.writethedocs.org/organizer-guide/confs/website/
+- Validation script: `docs/_scripts/validate-yaml.sh`
+- Schedule preview: `docs/_scripts/show-conf-schedule.py`

--- a/project-scope/wtd/writethedocs-conference-workflow/references/conference-flags.md
+++ b/project-scope/wtd/writethedocs-conference-workflow/references/conference-flags.md
@@ -1,0 +1,187 @@
+# Conference Flags Reference
+
+Complete reference for all conference feature flags used in Write the Docs conference configurations.
+
+## All Flags
+
+All flags are boolean values in the config YAML (`{shortcode}-{year}-config.yaml`).
+
+### flaglanding
+**When to enable**: Early announcement phase, before detailed info available
+**Controls**: Shows minimal landing page
+**Typical timeline**: Initial setup → CFP open
+
+### flagcfp
+**When to enable**: Call for Proposals is open
+**Controls**: CFP page displays submission form/link
+**Related fields**: `cfp_url`, `date.cfp_ends`
+**Typical timeline**: ~6 months before conference → speakers selected
+
+### flagspeakersannounced
+**When to enable**: Speaker lineup finalized and published
+**Controls**: Speakers page displays
+**Requirements**: Must have `{shortcode}-{year}-sessions.yaml` file
+**Typical timeline**: ~3 months before conference
+
+### flaghasschedule
+**When to enable**: Full conference schedule published
+**Controls**: Schedule page displays with times
+**Requirements**: Must have `{shortcode}-{year}-schedule.yaml` file
+**Typical timeline**: ~1-2 months before conference
+
+### flagticketsonsale
+**When to enable**: Tickets available for purchase
+**Controls**: Ticket purchase button/link displays
+**Related fields**: `tickets_url`, `date.tickets_live`
+**Typical timeline**: ~4 months before → sold out
+
+### flagsoldout
+**When to enable**: All tickets sold
+**Controls**: Shows sold-out notice, hides purchase link
+**Interaction**: Turn off `flagticketsonsale` when enabling this
+**Typical timeline**: When capacity reached
+
+### flaghasshirts
+**When to enable**: Conference shirts/swag available
+**Controls**: Shows shirt information
+**Typical timeline**: During ticket sales
+
+### flaghasfood
+**When to enable**: Food/venue information finalized
+**Controls**: Shows food/dietary options
+**Typical timeline**: ~1 month before conference
+
+### flaglivestreaming
+**When to enable**: During conference (livestream active)
+**Controls**: Shows livestream link
+**Related fields**: `livestream_url`
+**Typical timeline**: ~1 week before → end of conference
+
+### flagpostconf
+**When to enable**: After conference ends
+**Controls**: Switches to post-event mode
+**Typical timeline**: Day after conference ends
+
+### flagvideos
+**When to enable**: Conference videos published
+**Controls**: Video archive pages display
+**Requirements**: YouTube IDs in sessions YAML
+**Typical timeline**: ~2-4 weeks after conference
+
+## Flag Lifecycle
+
+Typical progression for a conference:
+
+```
+Setup Phase:
+  flaglanding: true
+
+CFP Phase:
+  flaglanding: false
+  flagcfp: true
+
+CFP Closed:
+  flagcfp: false
+
+Speakers Announced:
+  flagspeakersannounced: true
+  flagticketsonsale: true  # Usually simultaneous
+
+Schedule Published:
+  flaghasschedule: true
+  flaghasfood: true
+  flaghasshirts: true
+
+Sold Out (if applicable):
+  flagticketsonsale: false
+  flagsoldout: true
+
+Pre-Conference:
+  flaglivestreaming: true
+
+During Conference:
+  (flaglivestreaming remains true)
+
+Post-Conference:
+  flaglivestreaming: false
+  flagpostconf: true
+
+Videos Published:
+  flagvideos: true
+```
+
+## Example Config
+
+```yaml
+# Portland 2026 at different stages
+
+# Stage 1: Initial Setup
+flaglanding: true
+flagcfp: false
+flagspeakersannounced: false
+flag hasschedule: false
+flagticketsonsale: false
+flagsoldout: false
+flaghasshirts: false
+flaghasfood: false
+flaglivestreaming: false
+flagpostconf: false
+flagvideos: false
+
+# Stage 2: CFP Open
+flaglanding: false
+flagcfp: true
+# ... rest false
+
+# Stage 3: Speakers + Tickets
+flagcfp: false
+flagspeakersannounced: true
+flagticketsonsale: true
+# ... rest false
+
+# Stage 4: Schedule Published
+flagspeakersannounced: true
+flaghasschedule: true
+flagticketsonsale: true
+flaghasshirts: true
+flaghasfood: true
+# ... rest false
+
+# Stage 5: Post-Conference
+flagspeakersannounced: true
+flaghasschedule: true
+flagsoldout: true  # or flagticketsonsale: true if not sold out
+flaghasshirts: true
+flaghasfood: true
+flagpostconf: true
+# ... livestreaming false, videos not yet
+
+# Stage 6: Videos Published
+flagspeakersannounced: true
+flaghasschedule: true
+flagsoldout: true
+flaghasshirts: true
+flaghasfood: true
+flagpostconf: true
+flagvideos: true
+```
+
+## Testing Flags Locally
+
+Change flags in config YAML and rebuild:
+
+```bash
+# Edit config
+vim docs/_data/portland-2026-config.yaml
+
+# Validate
+cd docs/_scripts
+./validate-yaml.sh
+
+# Build and preview
+cd ../docs
+make clean html
+make livehtml
+```
+
+Check pages appear/disappear based on flags at http://127.0.0.1:8888

--- a/project-scope/wtd/writethedocs-documentation-standards/SKILL.md
+++ b/project-scope/wtd/writethedocs-documentation-standards/SKILL.md
@@ -1,0 +1,381 @@
+---
+name: writethedocs-documentation-standards
+description: RST/Markdown writing standards, Vale rules, YAML data management, and content guidelines for Write the Docs. Use when writing documentation, creating conference pages, or ensuring content meets style requirements.
+---
+
+# Write the Docs Documentation Standards
+
+This skill provides RST/Markdown formatting standards, Vale prose linting rules, YAML schema requirements, and content guidelines for the Write the Docs project.
+
+## When to Use This Skill
+
+Use this skill when:
+- Writing or editing RST/Markdown content
+- Creating conference pages with YAML data
+- Fixing Vale linting failures
+- Understanding heading capitalization rules
+- Managing conference YAML files
+- Ensuring content meets community standards
+
+## File Formats
+
+Write the Docs uses multiple formats:
+- **1,644 RST files** (primary format)
+- **108 Markdown files** (secondary, mainly conferences)
+- **100+ YAML files** (conference data)
+
+Both RST and Markdown supported via Sphinx + myst-parser.
+
+## RST/Markdown Style Standards
+
+### Heading Capitalization
+
+**Rule**: Use sentence case for all headings
+
+**Correct**:
+```rst
+This is a proper heading
+========================
+
+Getting started with documentation
+-----------------------------------
+```
+
+**Wrong**:
+```rst
+This Is A Proper Heading
+========================
+
+Getting Started With Documentation
+-----------------------------------
+```
+
+**Exceptions** (proper nouns always capitalized):
+- Write the Docs
+- Read the Docs
+- Sphinx
+- Git, GitHub
+- API, REST, JSON
+- Python, JavaScript
+- macOS, Linux, Windows
+
+### Branding Guidelines
+
+**Strict enforcement** (error level):
+
+**Write the Docs**:
+- ✅ "Write the Docs"
+- ❌ "Write The Docs"
+- ❌ "Write the docs"
+- ✅ "WTD" (acronym acceptable)
+
+**Read the Docs**:
+- ✅ "Read the Docs"
+- ❌ "Read The Docs"
+- ❌ "ReadTheDocs"
+
+### Inclusivity Rules
+
+**Replace problematic terms**:
+- ❌ "tribe" → ✅ "people", "group", "team"
+- Avoid gendered language when gender-neutral alternatives exist
+- Use "they/them" as singular pronoun
+
+### Sentence Length
+
+**Guideline**: Maximum 28 words per sentence (suggestion, not error)
+
+**Why**: Improves readability and scannability
+
+**How to fix**: Split long sentences with periods or semicolons
+
+### Writing Tone
+
+From contributing guide:
+- Use friendly and encouraging tone
+- Write for a general audience
+- Avoid tool advocacy - present use cases and results
+- Focus on general principles, not personal preferences
+- Attribute links and explain why they're useful
+
+## Vale Enforcement Levels
+
+Write the Docs uses **3 Vale configurations** with different strictness:
+
+### 1. General Content (`vale/vale.ini`)
+
+**Applies to**: Most documentation pages
+
+**Rules**:
+- WTD styles (headings, branding, inclusivity)
+- proselint (many rules disabled for legacy content)
+- TheEconomist.Hectoring
+- Warning level minimum
+
+**Test locally**:
+```bash
+vale --config=vale/vale.ini docs/
+```
+
+### 2. Guide Content (`vale/guide.ini`)
+
+**Applies to**: `docs/guide/` directory
+
+**Rules** (stricter):
+- All WTD styles enforced
+- Heading sentence case (error level)
+- Inclusivity rules (error level)
+- Gender bias checking enabled
+- Sentence length enforced
+
+**Test locally**:
+```bash
+vale --config=vale/guide.ini docs/guide/
+```
+
+### 3. Conference News (`vale/news.ini`)
+
+**Applies to**: `docs/conf/**/news/*`
+
+**Rules** (minimal):
+- Don't use `.. contents::` directive in newsletter posts
+- Error level enforcement
+
+**Test locally**:
+```bash
+vale --config=vale/news.ini --glob=docs/conf/**/news/* docs
+```
+
+### Common Vale Failures
+
+**Heading capitalization**:
+```rst
+# Wrong
+Getting Started With The API
+=============================
+
+# Correct
+Getting started with the API
+=============================
+```
+
+**Branding**:
+```rst
+# Wrong
+The Write The Docs community...
+
+# Correct
+The Write the Docs community...
+```
+
+**Sentence length**:
+```rst
+# Too long (>28 words)
+This is an example of a sentence that goes on for far too long without any breaks and makes it difficult for readers to follow the main point being conveyed.
+
+# Better (split into two)
+This sentence is too long without breaks. It makes it difficult for readers to follow the main point.
+```
+
+## YAML Data Standards
+
+All conference YAML must validate against schemas in `docs/_data/schema-*.yaml`.
+
+See `references/yaml-schemas.md` for complete details.
+
+### Three YAML Types
+
+**1. Config YAML** (`{shortcode}-{year}-config.yaml`):
+- Conference metadata (name, dates, location)
+- Sponsor information
+- Feature flags (flagcfp, flagspeakersannounced, etc.)
+- Timezone and time format settings
+
+**2. Sessions YAML** (`{shortcode}-{year}-sessions.yaml`):
+- Speaker information (name, bio, photo)
+- Talk details (title, abstract, slug)
+- YouTube video IDs (post-conference)
+
+**3. Schedule YAML** (`{shortcode}-{year}-schedule.yaml`):
+- Time-ordered conference agenda
+- Links to sessions via slugs
+- Break times, meals, social events
+- Multi-timezone support
+
+### YAML Validation
+
+**Required before PR**:
+```bash
+cd docs/_scripts
+./validate-yaml.sh
+```
+
+**Common validation errors**:
+- Missing required fields
+- Wrong data types (string instead of int)
+- Invalid enum values (time_format must be '12h' or '24h')
+- Malformed YAML syntax (tabs instead of spaces)
+
+### YAML Linting
+
+**Configuration**: `.yamllint.yaml` (relaxed rules)
+
+Disabled rules:
+- line-length
+- hyphens
+- new-line-at-end-of-file
+- trailing-spaces
+
+Focus is on schema validation, not formatting nitpicks.
+
+## Conference Page Structure
+
+### Required Metadata
+
+Every conference index.rst must have:
+
+```rst
+:template: {{year}}/index.html
+:banner: _static/conf/images/headers/{{shortcode}}-{{year}}-small-group.jpg
+:og:image: _static/conf/images/headers/{{shortcode}}-{{year}}-opengraph.png
+:orphan:
+
+.. title:: Home | Write the docs {{ name }} {{ year }}
+```
+
+### Standard Pages
+
+```
+conf/{shortcode}/{year}/
+├── index.rst           # Homepage
+├── cfp.rst            # Call for proposals
+├── schedule.rst       # Conference schedule
+├── speakers.rst       # Speaker list
+├── tickets.rst        # Ticket information
+├── sponsors/          # Sponsorship info
+├── news/              # Conference announcements
+├── venue.rst          # Venue details (if applicable)
+└── team.rst           # Organizing team
+```
+
+### File Naming Conventions
+
+**RST files**: lowercase-with-hyphens.rst
+- `code-of-conduct.rst`
+- `getting-started.rst`
+- `contribution-guide.rst`
+
+**YAML data files**: `{shortcode}-{year}-{type}.yaml`
+- `berlin-2025-config.yaml`
+- `portland-2025-sessions.yaml`
+- `atlantic-2024-schedule.yaml`
+
+**Schemas**: `schema-{type}.yaml`
+- `schema-config.yaml`
+- `schema-sessions.yaml`
+- `schema-schedule.yaml`
+
+## Python Code Standards
+
+When writing custom Sphinx extensions or scripts:
+
+**Style**:
+- 4-space indentation (not tabs)
+- snake_case for functions and variables
+- Descriptive variable names
+- Clear docstrings explaining purpose and return values
+
+**No automated linters** configured (no black, flake8, pylint)
+
+**Example from `docs/_ext/core.py`**:
+```python
+def load_conference_page_context(app, page):
+    """
+    Check whether this is a conference page, and if so, have the
+    conference specific YAML data loaded.
+    Conference data is cached, so only loaded once.
+
+    Returns an empty dict if it isn't run on a proper conference page.
+    """
+    # Implementation...
+```
+
+**Security**:
+- Use `yaml.safe_load()` not `yaml.load()`
+- Explicitly specify UTF-8 encoding for file operations
+- Handle exceptions with descriptive error messages
+
+## Content Guidelines
+
+From `docs/guide/contributing.rst`:
+
+**1. Use friendly tone**
+- Encourage contributors
+- Be welcoming to all experience levels
+
+**2. Attribute sources**
+- Link to original sources
+- Explain why links are useful
+- Give credit where due
+
+**3. Focus on principles**
+- General best practices, not personal preferences
+- Applicable across tools and contexts
+
+**4. Avoid tool advocacy**
+- Present use cases and results
+- Let readers choose appropriate tools
+- Document what works, not what you prefer
+
+**5. General audience**
+- Content should interest broad readership
+- Not overly specific to niche use cases
+- Explain technical concepts clearly
+
+## AI-Friendly Documentation (2025 Best Practices)
+
+From Write the Docs newsletter:
+
+**1. Structured writing**
+- Use clear headings and organization
+- Consistent naming for features/processes
+- Standard documentation patterns
+
+**2. Clear language**
+- Write in second person ("you" not "we" or "they")
+- Simple, direct sentences
+- Active voice preferred
+
+**3. Enhanced FAQs**
+- Add FAQ sections to pages
+- Include extra detail and context
+- Help both humans and AI find answers
+
+**Writing well for humans makes documentation usable for everyone**, including AI systems.
+
+## Screenshot Guidelines
+
+When adding images to documentation:
+
+**Technical requirements**:
+- Capture from laptop/desktop (not mobile)
+- Maximum width: 1000px
+- Thin black border to distinguish from background
+- Descriptive file names
+
+**Content requirements**:
+- Blur or anonymize real data
+- Use believable but fictional data in examples
+- Protect user privacy
+
+**Accessibility**:
+- Descriptive alt text (brief but accurate)
+- Don't rely solely on images to convey information
+- Supplement with text descriptions
+
+## Additional Resources
+
+- See `references/vale-rules.md` for complete Vale configuration
+- See `references/yaml-schemas.md` for detailed schema requirements
+- Contributing guide: https://www.writethedocs.org/guide/contributing/
+- Style guide principles: https://www.writethedocs.org/guide/

--- a/project-scope/wtd/writethedocs-documentation-standards/references/vale-rules.md
+++ b/project-scope/wtd/writethedocs-documentation-standards/references/vale-rules.md
@@ -1,0 +1,425 @@
+# Vale Rules Reference
+
+Complete reference for Vale prose linting rules used in Write the Docs.
+
+## Vale Configurations
+
+Write the Docs uses 3 separate Vale configurations with different rule sets:
+
+1. **General content** (`vale/vale.ini`) - Most pages
+2. **Guide content** (`vale/guide.ini`) - `docs/guide/` directory (stricter)
+3. **Conference news** (`vale/news.ini`) - `docs/conf/**/news/*` (minimal)
+
+## WTD Custom Rules
+
+Located in `vale/WTD/` directory.
+
+### Headings (`WTD/headings.yml`)
+
+**Rule**: Headings must use sentence case
+
+**Error level**: error
+
+**Regex pattern**: Matches title case headings (multiple capitalized words)
+
+**Exceptions** (proper nouns):
+- Write the Docs
+- Read the Docs
+- Sphinx
+- reStructuredText
+- Git, GitHub, GitLab
+- API, REST, JSON, XML, HTML, CSS
+- Python, JavaScript, Ruby, Go
+- Linux, macOS, Windows
+- MySQL, PostgreSQL
+- Docker, Kubernetes
+
+**Examples**:
+
+```rst
+# Wrong (Title Case)
+Getting Started With The API
+=============================
+
+How To Write Good Documentation
+--------------------------------
+
+# Correct (Sentence case)
+Getting started with the API
+=============================
+
+How to write good documentation
+----------------------------------
+
+# Correct (Proper nouns capitalized)
+Using the Sphinx documentation tool
+====================================
+
+Integrating with the GitHub API
+================================
+```
+
+### Branding (`WTD/Branding.yml`)
+
+**Rule**: Enforce correct branding for Write the Docs and Read the Docs
+
+**Error level**: error
+
+**Patterns**:
+
+**Write the Docs**:
+- ✅ "Write the Docs"
+- ❌ "Write The Docs"
+- ❌ "write the docs"
+- ❌ "Write the docs"
+- ✅ "WTD" (acronym OK)
+
+**Read the Docs**:
+- ✅ "Read the Docs"
+- ❌ "Read The Docs"
+- ❌ "ReadTheDocs"
+- ❌ "read the docs"
+
+**Examples**:
+
+```rst
+# Wrong
+The Write The Docs community hosts annual conferences.
+Read The Docs provides free hosting for documentation.
+
+# Correct
+The Write the Docs community hosts annual conferences.
+Read the Docs provides free hosting for documentation.
+
+# Acronym acceptable
+Join the WTD Slack for community discussion.
+```
+
+### Inclusivity (`WTD/inclusivity.yml`)
+
+**Rule**: Replace "tribe" with more inclusive terms
+
+**Error level**: error
+
+**Replacement suggestions**:
+- people
+- group
+- team
+- community
+
+**Example**:
+
+```rst
+# Wrong
+Find your tribe of documentarians.
+
+# Correct
+Find your people of documentarians.
+Find your community of documentarians.
+```
+
+### Inclusivity Avoid (`WTD/inclusivity-avoid.yml`)
+
+**Rule**: Avoid non-inclusive language
+
+**Error level**: error
+
+**Additional patterns** (beyond "tribe"):
+- Gendered language where gender-neutral exists
+- Unnecessarily gendered pronouns
+
+**Best practice**: Use "they/them" as singular pronoun
+
+**Example**:
+
+```rst
+# Less inclusive
+When a developer writes his code, he should document it.
+
+# More inclusive
+When a developer writes their code, they should document it.
+When developers write code, they should document it.
+```
+
+### Sentence Length (`WTD/SentenceLength.yml`)
+
+**Rule**: Sentences should not exceed 28 words
+
+**Error level**: suggestion (not error)
+
+**Why**: Improves readability and scannability
+
+**Example**:
+
+```rst
+# Too long (38 words)
+This is an example of a sentence that goes on for far too long without any breaks which makes it difficult for readers to follow the main point that is being conveyed and may cause confusion.
+
+# Better (split into two sentences, 19 + 11 words)
+This sentence is too long without breaks, making it difficult for readers to follow the main point. Split long sentences to improve readability.
+```
+
+### Newsletter Contents (`WTD/contents.yml`)
+
+**Rule**: Don't use `.. contents::` directive in newsletter posts
+
+**Error level**: error
+
+**Applies to**: Conference news only (`vale/news.ini`)
+
+**Reason**: Newsletter format doesn't support table of contents
+
+**Example**:
+
+```rst
+# Wrong (in newsletter post)
+.. contents::
+   :local:
+   :depth: 2
+
+# Correct (omit TOC in newsletters)
+# Just write content directly
+```
+
+## Proselint Rules
+
+Located in `vale/proselint/` directory.
+
+Write the Docs uses proselint but **many rules are disabled** for legacy content compatibility.
+
+**Enabled proselint rules**:
+- Basic grammar checks
+- Some redundancy detection
+- Obvious style issues
+
+**Disabled proselint rules** (many):
+- Strict style preferences
+- Rules that conflict with technical writing
+- Rules with too many false positives on legacy content
+
+**Note**: Proselint rules apply at warning level for general content, higher for guide content.
+
+## TheEconomist Rules
+
+Located in `vale/TheEconomist/` directory.
+
+**Enabled rule**:
+- `Hectoring.yml` - Avoid hectoring/preachy tone
+
+**Level**: warning
+
+**Example**:
+
+```rst
+# Hectoring (avoid)
+You must always write documentation.
+You should never skip tests.
+
+# Better
+Write documentation for all features.
+Include tests for new functionality.
+```
+
+## Configuration Files
+
+### General Content (`vale/vale.ini`)
+
+```ini
+StylesPath = vale
+MinAlertLevel = warning
+
+[*.{rst,md}]
+BasedOnStyles = WTD, proselint
+WTD.headings = YES
+WTD.Branding = YES
+WTD.inclusivity = YES
+WTD.inclusivity-avoid = YES
+WTD.SentenceLength = suggestion
+TheEconomist.Hectoring = warning
+
+# Many proselint rules disabled for legacy content
+proselint.Very = NO
+proselint.Cliches = NO
+# ... many more disabled
+```
+
+### Guide Content (`vale/guide.ini`)
+
+```ini
+StylesPath = vale
+MinAlertLevel = error  # Stricter!
+
+[*.{rst,md}]
+BasedOnStyles = WTD, proselint
+WTD.headings = error
+WTD.Branding = error
+WTD.inclusivity = error
+WTD.inclusivity-avoid = error
+WTD.SentenceLength = error  # Enforced for guide!
+
+# Fewer proselint rules disabled
+# Guide content held to higher standard
+```
+
+### Conference News (`vale/news.ini`)
+
+```ini
+StylesPath = vale
+MinAlertLevel = error
+
+[*.{rst,md}]
+BasedOnStyles = WTD
+WTD.contents = error  # Only check for contents directive
+
+# Minimal rules for announcements
+```
+
+## Testing Locally
+
+### General Content
+
+```bash
+vale --config=vale/vale.ini docs/
+
+# Specific file
+vale --config=vale/vale.ini docs/guide/contributing.rst
+
+# Ignore warnings, errors only
+vale --config=vale/vale.ini --minAlertLevel=error docs/
+```
+
+### Guide Content
+
+```bash
+vale --config=vale/guide.ini docs/guide/
+
+# Single file
+vale --config=vale/guide.ini docs/guide/writing/style-guides.rst
+```
+
+### Conference News
+
+```bash
+vale --config=vale/news.ini --glob='docs/conf/**/news/*' docs
+
+# Specific conference
+vale --config=vale/news.ini docs/conf/portland/2025/news/
+```
+
+## CI/CD Integration
+
+**Workflow file**: `.github/workflows/vale.yml`
+
+**Three separate checks**:
+1. Vale general (uses `vale/vale.ini`)
+2. Vale guide (uses `vale/guide.ini`)
+3. Vale news (uses `vale/news.ini`)
+
+**Reporter**: reviewdog (comments directly on PR)
+
+**Failure behavior**: All must pass (fail_on_error: true)
+
+## Common Vale Failures and Fixes
+
+### Heading Capitalization
+
+```
+docs/guide/api-documentation.rst:15:1: error: Headings must use sentence case
+    Writing API Documentation
+```
+
+**Fix**: Change to sentence case
+```rst
+# Before
+Writing API Documentation
+=========================
+
+# After
+Writing API documentation
+=========================
+```
+
+### Branding
+
+```
+docs/conf/portland/2025/index.rst:22:5: error: Use 'Write the Docs' not 'Write The Docs'
+    Welcome to Write The Docs Portland 2025
+```
+
+**Fix**: Correct capitalization
+```rst
+# Before
+Welcome to Write The Docs Portland 2025
+
+# After
+Welcome to Write the Docs Portland 2025
+```
+
+### Sentence Length
+
+```
+docs/guide/writing.rst:45:1: suggestion: Sentence is too long (32 words)
+```
+
+**Fix**: Split into multiple sentences
+```rst
+# Before
+This sentence contains far too many words and subordinate clauses which make it difficult to read and understand the main point being communicated.
+
+# After
+This sentence is too long. Split it into shorter sentences for better readability.
+```
+
+### Inclusivity
+
+```
+docs/guide/community.rst:78:10: error: Replace 'tribe' with 'people', 'group', or 'team'
+    Find your tribe at Write the Docs
+```
+
+**Fix**: Use inclusive term
+```rst
+# Before
+Find your tribe at Write the Docs
+
+# After
+Find your people at Write the Docs
+Find your community at Write the Docs
+```
+
+## Ignoring Vale Warnings
+
+**Rarely necessary** - fix the issue instead!
+
+If absolutely needed (false positive):
+
+```rst
+<!-- vale off -->
+This text will not be checked by Vale.
+<!-- vale on -->
+```
+
+**Better approach**: Update Vale rules if there are systematic false positives.
+
+## Vale Version
+
+Write the Docs uses **Vale 3.4.2**
+
+Specified in `.github/workflows/vale.yml`:
+```yaml
+version: 3.4.2
+```
+
+Ensure local Vale matches CI version for consistent results.
+
+## Adding New Rules
+
+If proposing new Vale rules:
+
+1. Create rule file in `vale/WTD/`
+2. Test thoroughly on existing content
+3. Update configurations (`vale.ini`, `guide.ini`)
+4. Document in this file
+5. Submit PR with justification
+
+**Note**: New rules should not break existing content unless fixing systematic issues.

--- a/project-scope/wtd/writethedocs-documentation-standards/references/yaml-schemas.md
+++ b/project-scope/wtd/writethedocs-documentation-standards/references/yaml-schemas.md
@@ -1,0 +1,439 @@
+# YAML Schemas Reference
+
+This document provides detailed information about the three YAML schemas used for Write the Docs conference data.
+
+All conference YAML files must validate against these schemas using the `validate-yaml.sh` script.
+
+## Schema Files
+
+Located in `docs/_data/`:
+- `schema-config.yaml` - Conference configuration
+- `schema-sessions.yaml` - Speaker sessions and talks
+- `schema-schedule.yaml` - Conference schedule/agenda
+
+## Validation Tool
+
+**Location**: `docs/_scripts/validate-yaml.sh`
+
+**Usage**:
+```bash
+cd docs/_scripts
+./validate-yaml.sh
+```
+
+**What it validates**:
+- All `*-config.yaml` files against `schema-config.yaml`
+- All `*-sessions.yaml` files against `schema-sessions.yaml`
+- All `*-schedule.yaml` files against `schema-schedule.yaml`
+
+## Config Schema (`schema-config.yaml`)
+
+### Required Fields
+
+```yaml
+name: str()                    # Conference name (e.g., "Portland")
+shortcode: str()               # Short identifier (e.g., "portland", "berlin")
+year: int()                    # Conference year (e.g., 2025)
+city: str()                    # City name
+local_area: str()             # Neighborhood/area
+area: str()                    # Country or region
+tz: str()                      # Timezone (e.g., "America/Los_Angeles", "Europe/Berlin")
+email: str()                   # Contact email
+color: str()                   # Primary color for conference branding
+```
+
+### Optional Fields
+
+```yaml
+time_format: enum('24h', '12h')  # Time display format (default: varies by location)
+tz2: str()                        # Second timezone for multi-TZ display
+tz2_
+
+color: str()                      # Second timezone color
+cfp_url: str()                    # Call for Proposals URL
+tickets_url: str()                # Ticket sales URL
+livestream_url: str()             # Livestream link
+```
+
+### Feature Flags (boolean)
+
+```yaml
+flaglanding: bool()              # Show landing page
+flagcfp: bool()                  # CFP is open
+flagspeakersannounced: bool()    # Speakers have been announced
+flaghasschedule: bool()          # Schedule is published
+flagticketsonsale: bool()        # Tickets are on sale
+flagsoldout: bool()              # Conference is sold out
+flaghasshirts: bool()            # Shirts available
+flaghasfood: bool()              # Food information available
+flaglivestreaming: bool()        # Livestream is active
+flagpostconf: bool()             # Post-conference mode
+flagvideos: bool()               # Videos are published
+```
+
+### Sponsor Data
+
+```yaml
+sponsors:
+  keystone:
+    - name: str()
+      link: str()
+      brand: str()  # Filename in _static/img/sponsors/
+  publisher:
+    - name: str()
+      link: str()
+      brand: str()
+  patron:
+    - name: str()
+      link: str()
+      brand: str()
+  # ... other sponsorship tiers
+```
+
+### Dates
+
+```yaml
+date:
+  main: str()                    # Main conference dates (e.g., "May 4-6, 2025")
+  cfp_ends: str()                # CFP deadline
+  tickets_live: str()            # Ticket sales start
+  unconf:
+    - str()                      # Unconference dates (list)
+  talks:
+    - str()                      # Talk dates (list)
+  job_fair: str()                # Job fair date
+```
+
+### Example Config YAML
+
+```yaml
+name: Portland
+shortcode: portland
+year: 2025
+city: Portland
+local_area: North Portland
+area: Oregon, USA
+tz: America/Los_Angeles
+email: portland@writethedocs.org
+color: green
+time_format: 12h
+
+flaglanding: false
+flagcfp: false
+flagspeakersannounced: true
+flaghasschedule: true
+flagticketsonsale: true
+flagsoldout: false
+flaghasshirts: true
+flaghasfood: true
+flaglivestreaming: false
+flagpostconf: false
+flagvideos: false
+
+date:
+  main: "**May 4-6, 2025**"
+  talks:
+    - "May 5-6"
+  unconf:
+    - "May 4"
+  cfp_ends: "January 15, 2025"
+  tickets_live: "February 1, 2025"
+
+sponsors:
+  keystone:
+    - name: GitBook
+      link: https://www.gitbook.com/
+      brand: GitBook.png
+  # ... more sponsors
+```
+
+## Sessions Schema (`schema-sessions.yaml`)
+
+### Required Fields
+
+```yaml
+slug: str()                    # Unique identifier for session
+title: str()                   # Talk title
+speakers:                      # List of speakers
+  - name: str()                # Speaker name
+    slug: str()                # Speaker slug (for photo/bio)
+    details: str()             # Speaker bio/details
+abstract: str()                # Talk abstract/description
+```
+
+### Optional Fields
+
+```yaml
+youtubeId: str()              # YouTube video ID (post-conference)
+```
+
+### Speaker Photo Management
+
+Speaker photos stored in `docs/_static/img/speakers/`:
+- Filename: `{speaker_slug}.{jpg|jpeg|png}`
+- Falls back to `missing.jpg` if not found
+- Custom Jinja filter `speaker_photo()` locates photos
+
+### Example Sessions YAML
+
+```yaml
+- title: Documentation as code
+  slug: documentation-as-code
+  speakers:
+    - name: Jane Smith
+      slug: jane-smith
+      details: >
+        Jane Smith is a technical writer at Example Corp,
+        where she leads the docs-as-code initiative.
+        She has 10 years of experience in developer documentation.
+  abstract: >
+    This talk explores treating documentation like code:
+    version control, automated testing, and continuous deployment.
+    Learn how to build a docs-as-code workflow that scales.
+  youtubeId: abc123xyz
+
+- title: Writing for developers
+  slug: writing-for-developers
+  speakers:
+    - name: John Doe
+      slug: john-doe
+      details: >
+        John Doe is a developer advocate with a passion
+        for clear, concise technical writing.
+  abstract: >
+    Developers need different documentation than end users.
+    This talk covers how to write effective API docs,
+    code samples, and getting started guides.
+```
+
+## Schedule Schema (`schema-schedule.yaml`)
+
+### Required Fields
+
+```yaml
+time: str()                    # Time in format "HH:MM" (24-hour)
+title: str()                   # Event title
+```
+
+### Optional Fields
+
+```yaml
+slug: str()                    # Links to session in sessions YAML
+icon: str()                    # Icon type (food, talk, etc.)
+```
+
+### Time Format
+
+- Always use 24-hour format in YAML: `"09:00"`, `"14:30"`
+- Display format (12h/24h) controlled by config `time_format`
+- Timezone conversion automatic based on conference `tz`
+
+### Schedule Event Types
+
+**Talk** (has slug):
+```yaml
+- time: "10:00"
+  title: Documentation as code
+  slug: documentation-as-code
+```
+
+**Break** (no slug):
+```yaml
+- time: "10:30"
+  title: Morning break
+  icon: food
+```
+
+**Meal**:
+```yaml
+- time: "12:00"
+  title: Lunch
+  icon: food
+```
+
+**Social Event**:
+```yaml
+- time: "18:00"
+  title: Reception
+  icon: social
+```
+
+### Multi-Day Schedules
+
+Organized by day using YAML structure:
+
+```yaml
+unconf:
+  - time: "09:00"
+    title: Unconference Kickoff
+  - time: "10:00"
+    title: Unconference Sessions
+  # ... more events
+
+talks_day1:
+  - time: "09:00"
+    title: Registration
+  - time: "10:00"
+    title: Opening Remarks
+  - time: "10:15"
+    title: Keynote
+    slug: keynote-speaker
+  # ... more events
+
+talks_day2:
+  - time: "09:00"
+    title: Doors Open
+  - time: "10:00"
+    title: Morning Session
+    slug: morning-talk
+  # ... more events
+```
+
+### Example Schedule YAML
+
+```yaml
+unconf:
+  - time: "09:00"
+    title: Doors Open
+    icon: door
+  - time: "10:00"
+    title: Writing Day Introduction
+  - time: "10:30"
+    title: Writing Sessions
+  - time: "12:00"
+    title: Lunch
+    icon: food
+  - time: "13:00"
+    title: Afternoon Writing Sessions
+  - time: "17:00"
+    title: Day 1 Wrap-Up
+
+talks_day1:
+  - time: "08:00"
+    title: Doors Open
+  - time: "09:00"
+    title: Welcome and Orientation
+  - time: "09:30"
+    title: Opening Keynote
+    slug: keynote-2025
+  - time: "10:15"
+    title: Morning Break
+    icon: food
+  - time: "10:45"
+    title: Documentation as Code
+    slug: documentation-as-code
+  - time: "11:30"
+    title: Writing for Developers
+    slug: writing-for-developers
+  - time: "12:15"
+    title: Lunch
+    icon: food
+  - time: "14:00"
+    title: Afternoon Session 1
+    slug: afternoon-talk-1
+  - time: "14:45"
+    title: Lightning Talks
+  - time: "15:30"
+    title: Afternoon Break
+    icon: food
+  - time: "16:00"
+    title: Afternoon Session 2
+    slug: afternoon-talk-2
+  - time: "16:45"
+    title: Unconference Reports
+  - time: "17:30"
+    title: Day 1 Closing
+  - time: "18:00"
+    title: Reception
+    icon: social
+
+talks_day2:
+  - time: "08:00"
+    title: Doors Open
+  - time: "09:00"
+    title: Day 2 Welcome
+  - time: "09:15"
+    title: Morning Keynote
+    slug: day2-keynote
+  # ... similar structure to day 1
+```
+
+## Common Validation Errors
+
+### Missing Required Fields
+
+```
+Error: Required field 'name' missing in config
+```
+
+**Fix**: Add all required fields from schema
+
+### Wrong Data Type
+
+```
+Error: Expected int for 'year', got string
+```
+
+**Fix**: Remove quotes from integers
+```yaml
+# Wrong
+year: "2025"
+
+# Correct
+year: 2025
+```
+
+### Invalid Enum Value
+
+```
+Error: 'time_format' must be '12h' or '24h', got '24-hour'
+```
+
+**Fix**: Use exact enum values from schema
+```yaml
+# Wrong
+time_format: 24-hour
+
+# Correct
+time_format: 24h
+```
+
+### Malformed YAML Syntax
+
+```
+Error: YAML parse error - tabs not allowed
+```
+
+**Fix**: Use spaces, not tabs for indentation
+
+### Orphaned Schedule Slugs
+
+```
+Warning: Schedule slug 'talk-foo' not found in sessions YAML
+```
+
+**Fix**: Ensure all schedule slugs reference valid sessions
+
+## Validation Workflow
+
+1. **Create/Edit YAML files**
+2. **Run validation**:
+   ```bash
+   cd docs/_scripts
+   ./validate-yaml.sh
+   ```
+3. **Fix any errors** reported
+4. **Re-run** until all pass
+5. **Commit** changes
+
+**Always validate before creating a PR** - YAML validation is a required CI check.
+
+## Schema Updates
+
+If schemas need updating (rare):
+1. Edit `docs/_data/schema-*.yaml`
+2. Update all affected conference YAML files
+3. Test validation script
+4. Document changes in PR
+
+Schemas are intentionally strict to maintain data quality across all conferences.

--- a/project-scope/wtd/writethedocs-git-workflow/SKILL.md
+++ b/project-scope/wtd/writethedocs-git-workflow/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: writethedocs-git-workflow
+description: Git workflow, PR process, commit standards, and CI/CD requirements for contributing to Write the Docs (writethedocs.org). Use when creating pull requests, managing branches, or ensuring CI checks pass.
+---
+
+# Write the Docs Git Workflow
+
+This skill provides the git workflow, pull request process, commit message standards, and CI/CD requirements for contributing to the Write the Docs project (writethedocs.org repository).
+
+## When to Use This Skill
+
+Use this skill when:
+- Creating a pull request to Write the Docs
+- Setting up a fork-based workflow
+- Writing commit messages
+- Troubleshooting failed CI checks
+- Understanding what tests must pass before merge
+
+## Repository Information
+
+- **Upstream repository**: https://github.com/writethedocs/www
+- **Main branch**: `main` (not `master`)
+- **Workflow**: Fork-based contributions
+- **Python version**: 3.9 (migrating to 3.12)
+
+## Git Workflow
+
+### 1. Fork and Clone
+
+```bash
+# Fork writethedocs/www on GitHub first, then:
+git clone git@github.com:YOUR_USERNAME/writethedocs.git
+cd writethedocs
+
+# Add upstream remote
+git remote add upstream https://github.com/writethedocs/www.git
+
+# Verify remotes
+git remote -v
+```
+
+### 2. Create Feature Branch
+
+Use descriptive branch names with hyphens:
+
+```bash
+# Update your main branch first
+git checkout main
+git pull upstream main
+
+# Create feature branch
+git checkout -b descriptive-feature-name
+```
+
+**Good branch names**:
+- `fix-typo-in-contributing-guide`
+- `add-berlin-2025-speakers`
+- `update-python-dependencies`
+
+**Avoid**:
+- `patch-1` (non-descriptive)
+- `fix_stuff` (underscores, vague)
+- `MyFeature` (not lowercase)
+
+### 3. Make Changes and Commit
+
+**Commit message format**:
+- Use imperative mood ("Add feature" not "Added feature" or "Adding feature")
+- First line: concise summary (50-72 characters)
+- Optional body: detailed explanation after blank line
+- Reference PR numbers in format `(#1234)` when applicable
+
+**Good commit messages**:
+```
+Add Berlin 2025 thank you post (#2463)
+
+Update day of week dates for 2026 (#2475)
+
+Fix broken link in contributing guide
+
+Update dependencies for Python 3.12 migration
+
+- myst-parser: 0.18.0 → 4.0.1
+- lxml: 4.8.0 → 5.3.2
+- Werkzeug: 0.16.1 → 3.1.3
+```
+
+**Avoid**:
+```
+fixed stuff
+Updated files
+WIP
+asdf
+```
+
+### 4. Push and Create PR
+
+```bash
+# Push to your fork
+git push -u origin your-branch-name
+
+# Create PR on GitHub
+# Title should be descriptive, like commit message
+# Description should explain what/why
+```
+
+**PR best practices**:
+- Descriptive title (similar to commit message)
+- Clear description of changes and rationale
+- Reference related issues if applicable
+- Mark as draft if work-in-progress
+- For cross-repo PRs (fork to upstream): this is standard workflow
+
+## Required CI/CD Checks
+
+All pull requests must pass **6 automated checks** before merge. See `references/ci-checks.md` for detailed information.
+
+### Quick Overview
+
+1. **Ubuntu Build** - Sphinx build must succeed on Linux
+2. **Windows Build** - Sphinx build must succeed on Windows
+3. **Spellcheck** - No spelling errors (codespell)
+4. **Vale Linting** - 3 separate prose checks (general, guide, news)
+5. **YAML Validation** - All conference YAML must pass schema validation
+6. **Read the Docs Preview** - Automatic preview build
+
+### Common Failures and Fixes
+
+**Build failures**:
+```bash
+# Test locally first
+cd docs
+make clean html
+
+# Check for errors in output
+```
+
+**Spellcheck failures**:
+- Check `codespell/ignore.txt` for allowed exceptions
+- Fix actual typos (don't add to ignore list if it's a real error)
+
+**Vale failures**:
+- Most common: heading capitalization (must be sentence case)
+- Branding: "Write the Docs" not "Write The Docs"
+- Test locally: `vale --config=vale/vale.ini docs/`
+
+**YAML validation failures**:
+```bash
+# Run validation script
+cd docs/_scripts
+./validate-yaml.sh
+
+# Check schema files in docs/_data/schema-*.yaml
+```
+
+## Local Testing Before PR
+
+**Minimum testing**:
+```bash
+# 1. Build docs
+cd docs
+make clean html
+
+# 2. Check for warnings/errors in output
+
+# 3. Test live preview (optional but recommended)
+make livehtml
+# Open http://127.0.0.1:8888
+```
+
+**Comprehensive testing** (recommended for large changes):
+```bash
+# Run all local checks
+cd docs
+
+# Build
+make clean html
+
+# Spellcheck (if installed)
+codespell docs/
+
+# Vale linting (if installed)
+vale --config=vale/vale.ini docs/
+
+# YAML validation
+cd _scripts
+./validate-yaml.sh
+
+# Link checking (if Ruby/htmlproofer installed)
+cd ..
+bundle exec htmlproofer --ignore-files "/404/,/2013/,/2014/,/2015/,/2016/,/2017/,/search\/index.html/,/archive\/tag\/index/" \
+  --allow-hash-href=true --enforce-https=false --ignore-missing-alt=true --disable-external=true _build/html
+```
+
+## Cross-Repo PR Considerations
+
+When creating PRs from your fork to upstream `writethedocs/www`:
+
+**What to include**:
+- Only changes relevant to the feature/fix
+- No fork-specific files (like CLAUDE.md)
+- No local configuration changes
+
+**What to exclude**:
+- Add fork-specific files to `.git/info/exclude` (local-only ignore)
+- Use feature branches, not main branch
+- Keep main branch clean for syncing with upstream
+
+**Syncing with upstream**:
+```bash
+# Regularly update your fork's main branch
+git checkout main
+git pull upstream main
+git push origin main
+
+# Rebase feature branch if needed
+git checkout your-feature-branch
+git rebase main
+```
+
+## Team Review Process
+
+- **Community-driven reviews**: Anyone can review and comment
+- **Team leads**: Have final merge authority
+- **Response time**: Varies (community-driven, no SLA)
+- **Respectful communication**: Follow Code of Conduct
+
+## Additional Resources
+
+- See `references/ci-checks.md` for detailed CI/CD documentation
+- Contributing guide: https://www.writethedocs.org/guide/contributing/
+- Code of Conduct: https://www.writethedocs.org/code-of-conduct/

--- a/project-scope/wtd/writethedocs-git-workflow/references/ci-checks.md
+++ b/project-scope/wtd/writethedocs-git-workflow/references/ci-checks.md
@@ -1,0 +1,261 @@
+# CI/CD Checks Reference
+
+This document provides detailed information about the 6 automated CI/CD checks that must pass for all Write the Docs pull requests.
+
+## 1. Ubuntu Build
+
+**Workflow file**: `.github/workflows/ubuntu.yml`
+
+**What it does**:
+- Sets up Python 3.9 environment
+- Installs dependencies from `requirements.txt`
+- Builds documentation with `make html`
+- Runs htmlproofer to validate internal links
+- Archives built HTML as artifact
+
+**Build command**:
+```bash
+cd docs
+make html
+```
+
+**Link checking**:
+```bash
+bundle exec htmlproofer \
+  --ignore-files "/404/,/2013/,/2014/,/2015/,/2016/,/2017/,/search\/index.html/,/archive\/tag\/index/" \
+  --allow-hash-href=true \
+  --enforce-https=false \
+  --ignore-missing-alt=true \
+  --disable-external=true \
+  _build/html
+```
+
+**Common failures**:
+- Sphinx build errors (syntax errors in RST, missing files)
+- Broken internal links
+- Missing images or assets
+- Import errors in custom extensions
+
+**How to fix**:
+- Test build locally: `cd docs && make clean html`
+- Check build output for specific errors
+- Verify all referenced files exist
+- Test custom extensions in `docs/_ext/`
+
+## 2. Windows Build
+
+**Workflow file**: `.github/workflows/windows.yml`
+
+**What it does**:
+- Sets up Python 3.9 on Windows
+- Installs dependencies
+- Builds documentation with `make.bat html`
+- Ensures cross-platform compatibility
+
+**Common failures**:
+- Path separator issues (Windows uses `\` not `/`)
+- UTF-8 encoding problems
+- Line ending differences (CRLF vs LF)
+
+**How to fix**:
+- Check `docs/conf.py` for Windows-specific monkeypatch
+- Ensure UTF-8 encoding specified in Python file operations
+- Use `os.path.join()` for paths, not string concatenation
+
+## 3. Spellcheck
+
+**Workflow file**: `.github/workflows/spellcheck.yml`
+
+**What it does**:
+- Uses `codespell-project/actions-codespell`
+- Checks `docs/` directory for spelling errors
+- Skips: PDF, SVG, JS, CSS, SCSS files
+- Skips: Legacy conference data (2015-2017)
+- Custom ignore list in `codespell/ignore.txt`
+
+**Common failures**:
+- Actual typos in documentation
+- Technical terms not in dictionary
+- Brand names or proper nouns
+
+**How to fix**:
+1. Fix actual typos (preferred)
+2. If word is correct but flagged:
+   - Check if it's already in `codespell/ignore.txt`
+   - Add to ignore list ONLY if it's a legitimate technical term/name
+   - Don't add common words with typos
+
+**Local testing**:
+```bash
+codespell docs/
+```
+
+## 4. Vale Linting
+
+**Workflow file**: `.github/workflows/vale.yml`
+
+**What it does**:
+- Runs 3 separate Vale checks with different configurations
+- Uses Vale 3.4.2
+- Reports errors via reviewdog in PRs
+
+**Three configurations**:
+
+### 4a. General Content Check
+- Config: `vale/vale.ini`
+- Applies to: Most documentation
+- Rules: WTD styles + proselint (many disabled for legacy content)
+- Level: Warning minimum
+
+### 4b. Guide Content Check
+- Config: `vale/guide.ini`
+- Applies to: `docs/guide/` directory
+- Rules: Stricter enforcement
+- Checks: Heading capitalization, inclusivity, gender bias
+- Level: Error on violations
+
+### 4c. Conference News Check
+- Config: `vale/news.ini`
+- Applies to: `docs/conf/**/news/*`
+- Rules: Minimal (mainly `contents::` directive usage)
+- Level: Error on violations
+
+**Common failures**:
+
+**Heading capitalization**:
+- Must use sentence case: "This is a heading"
+- Not title case: "This Is A Heading"
+- Exceptions for proper nouns (API, Sphinx, Git, etc.)
+
+**Branding**:
+- "Write the Docs" (correct)
+- "Write The Docs" (wrong)
+- "Read the Docs" (correct)
+- "Read The Docs" (wrong)
+
+**Inclusivity**:
+- Replace "tribe" with "people"
+- Avoid gendered language
+
+**Sentence length**:
+- Suggested max 28 words per sentence
+- Suggestion level only (not error)
+
+**How to fix**:
+```bash
+# Test locally
+vale --config=vale/vale.ini docs/
+
+# Test guide content
+vale --config=vale/guide.ini docs/guide/
+
+# Test conference news
+vale --config=vale/news.ini --glob=docs/conf/**/news/* docs
+```
+
+**Vale rule files**:
+- `vale/WTD/headings.yml` - Heading capitalization
+- `vale/WTD/Branding.yml` - Brand names
+- `vale/WTD/inclusivity.yml` - Inclusive language
+- `vale/WTD/SentenceLength.yml` - Sentence length
+- `vale/WTD/contents.yml` - Newsletter TOC usage
+
+## 5. YAML Validation
+
+**Workflow file**: `.github/workflows/validate_yaml.yml`
+
+**What it does**:
+- Validates all conference YAML files against schemas
+- Uses yamale and ruamel.yaml
+- Runs `docs/_scripts/validate-yaml.sh`
+
+**Validated files**:
+- `docs/_data/*-config.yaml` against `schema-config.yaml`
+- `docs/_data/*-sessions.yaml` against `schema-sessions.yaml`
+- `docs/_data/*-schedule.yaml` against `schema-schedule.yaml`
+
+**Common failures**:
+- Missing required fields
+- Wrong data types (string vs int)
+- Invalid enum values
+- Malformed YAML syntax
+
+**How to fix**:
+```bash
+# Run validation locally
+cd docs/_scripts
+./validate-yaml.sh
+
+# Check schemas
+cat docs/_data/schema-config.yaml
+cat docs/_data/schema-sessions.yaml
+cat docs/_data/schema-schedule.yaml
+```
+
+**Schema requirements**:
+
+**Config schema** (key fields):
+```yaml
+name: str()  # Conference name
+shortcode: str()  # e.g., "berlin", "portland"
+year: int()  # e.g., 2025
+city: str()
+tz: str()  # Timezone (e.g., "Europe/Berlin")
+email: str()
+time_format: enum('24h', '12h', required=False)
+```
+
+**Sessions schema** (key fields):
+```yaml
+slug: str()  # Unique identifier
+title: str()  # Talk title
+speakers: list()  # Speaker names
+abstract: str()  # Talk description
+```
+
+**Schedule schema** (key fields):
+```yaml
+time: str()  # Time in format "HH:MM"
+title: str()  # Event title
+slug: str(required=False)  # Links to session
+```
+
+## 6. Read the Docs Preview
+
+**Workflow file**: `.github/workflows/documentation-links.yml`
+
+**What it does**:
+- Automatic preview build for PRs
+- Deploys to RTD preview environment
+- Provides link to view changes
+- Uses RTD's build configuration (`.readthedocs.yaml`)
+
+**Build configuration**:
+- OS: ubuntu-22.04
+- Python: 3.9
+- Builder: dirhtml (clean URLs)
+- No PDF generation
+
+**Common failures**:
+- Sphinx build errors (same as Ubuntu build)
+- RTD-specific issues (environment, dependencies)
+- Resource limits (timeout, memory)
+
+**How to fix**:
+- Same as Ubuntu build fixes
+- Check RTD build logs for specific errors
+- Ensure `.readthedocs.yaml` is correctly configured
+
+## Summary Checklist
+
+Before creating a PR, verify locally:
+
+- [ ] `cd docs && make clean html` succeeds
+- [ ] No warnings in Sphinx output
+- [ ] `codespell docs/` passes
+- [ ] `vale --config=vale/vale.ini docs/` passes
+- [ ] `cd docs/_scripts && ./validate-yaml.sh` passes
+- [ ] Test live preview: `make livehtml`
+- [ ] Check pages in browser at http://127.0.0.1:8888
+
+All 6 CI checks must pass before merge.


### PR DESCRIPTION
## Summary

Centralize skills from readthedocs.org and writethedocs repositories into this central skills repository.

- Migrated 3 skills from readthedocs.org to `project-scope/rtd/`
- Migrated 3 skills from writethedocs to `project-scope/wtd/`
- Created README.md files documenting each project's architecture
- Replaced original skill directories with symlinks in both repos
- Cleaned up .zip export artifacts from writethedocs repo

## Skills Migrated

**Read the Docs (`project-scope/rtd/`):**
- `rtd-code-standards` - Code quality and style standards for Python contributions
- `rtd-contribution-workflow` - Fork-based Git and PR workflow
- `rtd-docs-standards` - ReStructuredText documentation standards

**Write the Docs (`project-scope/wtd/`):**
- `writethedocs-conference-workflow` - Conference website management workflow
- `writethedocs-documentation-standards` - RST/Markdown standards, Vale rules, YAML schemas
- `writethedocs-git-workflow` - Git workflow, PR process, CI/CD checks

## Verification

- All skills verified with hash comparison before creating symlinks
- Symlinks tested and confirmed working in both original repos
- SKILL.md files readable through symlinks

## Changes to Other Repos

Both readthedocs.org and writethedocs repos now have symlinks in `.claude/skills/` pointing to this central repository. The .claude directory is excluded from git tracking in both repos (via .git/info/exclude), so these changes are local-only.

Generated with [Claude Code](https://claude.com/claude-code)