### PR TITLE
Stop symlinking CLAUDE.md in BroteinBuddy worktrees

### DIFF
--- a/project-scope/brotein-buddy/git-github-workflow/SKILL.md
+++ b/project-scope/brotein-buddy/git-github-workflow/SKILL.md
@@ -90,7 +90,7 @@ Branch: bug/123-fix-inventory       → Directory: bug-123-fix-inventory
 3. Creates new git branch from the source branch
 4. Assigns unique port for dev server (main=5173, others=random 10000-60000)
 5. Creates worktree at `<directory-name>/` (repo root level) tracking `<branch-name>`
-6. Symlinks shared files (CLAUDE.md, CLAUDE_CONTEXT.md, .planning, .scratch)
+6. Symlinks shared files (CLAUDE_CONTEXT.md, .planning, .scratch). CLAUDE.md is no longer symlinked — it is tracked in the BroteinBuddy repo and populated by `git checkout` automatically.
 7. Symlinks `.claude/` directory (settings.local.json, skills/, agents/)
 8. Creates `.env.local` with VITE_PORT and BASE_URL for parallel development
 9. Runs `npm install` to install dependencies

--- a/project-scope/brotein-buddy/git-github-workflow/scripts/setup-worktree.py
+++ b/project-scope/brotein-buddy/git-github-workflow/scripts/setup-worktree.py
@@ -412,9 +412,11 @@ def create_symlinks(wt_dir, repo_root):
         print("   Run init-shared.sh first")
         sys.exit(1)
 
-    # Create symlinks to root-level files
+    # Create symlinks to root-level files.
+    # CLAUDE.md is intentionally NOT symlinked here: it is now a tracked file
+    # in the BroteinBuddy repo, populated automatically by git checkout into
+    # every worktree. A symlink would shadow the tracked file.
     symlinks = [
-        ('CLAUDE.md', '../.shared/CLAUDE.md'),
         ('CLAUDE_CONTEXT.md', '../.shared/CLAUDE_CONTEXT.md'),
         ('.planning', '../.shared/.planning'),
         ('.scratch', '../.shared/.scratch'),
@@ -446,8 +448,9 @@ def create_symlinks(wt_dir, repo_root):
 def validate_and_fix_gitignore(wt_dir):
     """Validate .gitignore doesn't have problematic entries.
 
-    Note: Symlink entries (CLAUDE.md, .planning, .scratch, .claude/*, .env.local)
-    are now handled by .bare/info/exclude and should NOT be in .gitignore.
+    Note: Symlink entries (.planning, .scratch, .claude/*, .env.local) are
+    handled by .bare/info/exclude and should NOT be in .gitignore. CLAUDE.md
+    is no longer a symlink — it is tracked in git directly.
     """
     gitignore_path = wt_dir / '.gitignore'
 
@@ -547,7 +550,6 @@ def print_success_message(dir_name, branch, port):
     print(f"   Port: {port}")
     print()
     print("Shared items symlinked:")
-    print("  - CLAUDE.md (project context)")
     print("  - CLAUDE_CONTEXT.md (confidential info)")
     print("  - .planning/ (planning docs)")
     print("  - .scratch/ (throwaway files)")


### PR DESCRIPTION
## Summary

- Remove the `CLAUDE.md` entry from `setup-worktree.py`'s symlink list (and the matching docstring / success-message references).
- Update `SKILL.md` step 6 to match.

## Why

CLAUDE.md is moving from a shared, gitignored symlink (`.shared/CLAUDE.md` -> `main/CLAUDE.md`) to a **tracked file** in the BroteinBuddy repo. Once it is tracked, every worktree gets it automatically via `git checkout` — and the setup script's pre-existing symlink step would shadow the tracked file, breaking new worktrees.

CLAUDE_CONTEXT.md (confidential), `.planning/`, `.scratch/`, and the `.claude/` directory remain symlinked from `.shared/` — they are personal/scratch content that should not be committed.

## Sequencing

> [!IMPORTANT]
> This PR is a **hard prerequisite** for the companion BroteinBuddy PR that tracks `CLAUDE.md` in git. It must merge first to avoid creating broken new worktrees during the interim.

After merge:
1. Pull this change into any active BroteinBuddy worktrees that use the script.
2. Open the companion BroteinBuddy PR that adds `CLAUDE.md` to git, removes it from `.gitignore` and `.bare/info/exclude`, and deletes `.shared/CLAUDE.md`.

## Test Plan

- [x] `python3 -m ast` parses `setup-worktree.py` cleanly (syntax verified).
- [ ] After merge, re-run `setup-worktree.py` to create a throwaway worktree and confirm:
  - No `CLAUDE.md` symlink is created.
  - `CLAUDE_CONTEXT.md`, `.planning/`, `.scratch/`, `.claude/` symlinks are still created.
  - The success message no longer mentions `CLAUDE.md` in "Shared items symlinked".

🤖 Generated with [Claude Code](https://claude.com/claude-code)